### PR TITLE
Find by range

### DIFF
--- a/lib/google/calendar.rb
+++ b/lib/google/calendar.rb
@@ -71,7 +71,9 @@ module Google
     #   an array of events if many found.
     #
     def find_events_in_range(start_min, start_max)
-      event_lookup("?start-min=#{start_min.iso8601}&start-max=#{start_max.iso8601}")
+      formatted_start_min = start_min.strftime("%Y-%m-%dT%H:%M:%S")
+      formatted_start_max = start_max.strftime("%Y-%m-%dT%H:%M:%S")
+      event_lookup("?start-min=#{formatted_start_min}&start-max=#{formatted_start_max}")
     end
 
     # Attempts to find the event specified by the id

--- a/test/test_google_calendar.rb
+++ b/test/test_google_calendar.rb
@@ -89,7 +89,7 @@ class TestGoogleCalendar < Test::Unit::TestCase
       should "find events in range" do
         start_min = DateTime.new(2011, 2, 1, 11, 1, 1)
         start_max = DateTime.new(2011, 2, 28, 23, 59, 59)
-        @calendar.expects(:event_lookup).with('?start-min=2011-02-01T11:01:01+00:00&start-max=2011-02-28T23:59:59+00:00')
+        @calendar.expects(:event_lookup).with('?start-min=2011-02-01T11:01:01&start-max=2011-02-28T23:59:59')
         events = @calendar.find_events_in_range(start_min, start_max)
       end
 


### PR DESCRIPTION
I've added a method to the calendar class to let me pull events that fall in a set time frame.  The calendar that I'm pulling from has many events, but I'm really only interested in fetching a week at a time.  I'm open to any suggestions if there are better ways of doing this, as well.
