### PR TITLE
Added quick add events creation support

### DIFF
--- a/test/mocks/create_quickadd_event.xml
+++ b/test/mocks/create_quickadd_event.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<entry xmlns="http://www.w3.org/2005/Atom" xmlns:gCal="http://schemas.google.com/gCal/2005" xmlns:gd="http://schemas.google.com/g/2005">
+  <id>http://www.google.com/calendar/feeds/default/private/full/b1vq6rj4r4mg85kcickc7iomb0</id>
+  <published>2011-05-04T00:59:03.000Z</published>
+  <updated>2011-05-04T00:59:03.000Z</updated>
+  <category scheme="http://schemas.google.com/g/2005#kind" term="http://schemas.google.com/g/2005#event"/>
+  <title type="text">movie at AMC Van Ness</title>
+  <content type="text"/>
+  <link rel="alternate" type="text/html" href="https://www.google.com/calendar/event?eid=aW1vcnE4cHY5YWZlZ3R0ZDVlN3Fkc2ZidmcgYXluQGFuZHJld25nLmNvbQ" title="alternate"/>
+  <link rel="self" type="application/atom+xml" href="https://www.google.com/calendar/feeds/default/private/full/imorq8pv9afegttd5e7qdsfbvg"/>
+  <link rel="edit" type="application/atom+xml" href="https://www.google.com/calendar/feeds/default/private/full/imorq8pv9afegttd5e7qdsfbvg/63440153943"/>
+  <author>
+    <name>Some Guy</name>
+    <email>some.guy@gmail.com</email>
+  </author>
+  <gd:comments>
+    <gd:feedLink href="https://www.google.com/calendar/feeds/default/private/full/b1vq6rj4r4mg85kcickc7iomb0/comments"/>
+  </gd:comments>
+  <gd:eventStatus value="http://schemas.google.com/g/2005#event.confirmed"/>
+  <gd:where valueString="AMC Van Ness"/>
+  <gd:who email="some.guy@gmail.com" rel="http://schemas.google.com/g/2005#event.organizer" valueString="some.guy@gmail.com"/>
+  <gd:when endTime="2011-05-05T00:00:00.000-07:00" startTime="2011-05-04T23:00:00.000-07:00"/>
+  <gd:transparency value="http://schemas.google.com/g/2005#event.opaque"/>
+  <gd:visibility value="http://schemas.google.com/g/2005#event.default"/>
+  <gCal:anyoneCanAddSelf value="false"/>
+  <gCal:guestsCanInviteOthers value="true"/>
+  <gCal:guestsCanModify value="false"/>
+  <gCal:guestsCanSeeGuests value="true"/>
+  <gCal:sequence value="0"/>
+  <gCal:uid value="b1vq6rj4r4mg85kcickc7iomb0@google.com"/>
+</entry>

--- a/test/test_google_calendar.rb
+++ b/test/test_google_calendar.rb
@@ -118,6 +118,17 @@ class TestGoogleCalendar < Test::Unit::TestCase
         assert_equal event.title, 'New Event'
       end
 
+      should "create a quickadd event" do
+        @http_mock.stubs(:body).returns( get_mock_body("create_quickadd_event.xml") )
+
+        event = @calendar.create_event do |e|
+          e.content = "movie tomorrow 23:00 at AMC Van Ness"
+          e.quickadd = true
+        end
+
+        assert_equal event.content, "movie tomorrow 23:00 at AMC Van Ness"
+      end
+
       should "format to_s properly" do
         @http_mock.stubs(:body).returns( get_mock_body("query_events.xml") )
         event = @calendar.find_events('Test')


### PR DESCRIPTION
Hi there,

Thanks for sharing your google calendar gem, I needed a script to add events via "Quick Add" to my Google calendar, via Alfred/QuickSilver, so I added support for _quick add events_ to this. More info at http://bit.ly/j7gVtV

Thanks,

--Andrew
