### PR TITLE
Fetch calendar's event given a calendar name

### DIFF
--- a/lib/google/errors.rb
+++ b/lib/google/errors.rb
@@ -3,4 +3,5 @@ module Google
   class HTTPAuthorizationFailed < StandardError; end
   class HTTPNotFound < StandardError; end
   class HTTPTooManyRedirections < StandardError; end
+  class InvalidCalendar < StandardError; end
 end

--- a/test/mocks/list_calendars.xml
+++ b/test/mocks/list_calendars.xml
@@ -1,0 +1,89 @@
+<?xml version='1.0' encoding='utf-8'?>
+<feed xmlns='http://www.w3.org/2005/Atom'
+    xmlns:openSearch='http://a9.com/-/spec/opensearch/1.1/'
+    xmlns:gCal='http://schemas.google.com/gCal/2005'
+    xmlns:gd='http://schemas.google.com/g/2005'
+    gd:etag='W/"CkYFSHg-fyp7ImA9WxRVGUo."'>
+  <id>http://www.google.com/calendar/feeds/default/allcalendars/full</id>
+  <updated>2008-11-18T01:01:59.657Z</updated>
+  <title>Coach's Calendar List</title>
+  <link rel='alternate' type='text/html'
+    href='https://www.google.com/calendar/render' />
+  <link rel='http://schemas.google.com/g/2005#feed'
+    type='application/atom+xml'
+    href='https://www.google.com/calendar/feeds/default/allcalendars/full' />
+  <link rel='http://schemas.google.com/g/2005#post'
+    type='application/atom+xml'
+    href='https://www.google.com/calendar/feeds/default/allcalendars/full' />
+  <link rel='self' type='application/atom+xml'
+    href='https://www.google.com/calendar/feeds/default/allcalendars/full' />
+  <author>
+    <name>Coach</name>
+    <email>user@gmail.com</email>
+  </author>
+  <generator version='1.0' uri='http://www.google.com/calendar'>Google Calendar</generator>
+  <openSearch:startIndex>1</openSearch:startIndex>
+  <entry gd:etag='W/"DU4ERH47eCp7ImA9WxRVEkQ."'>
+    <id>http://www.google.com/calendar/feeds/default/allcalendars/full/user%40gmail.com</id>
+    <published>2007-07-11T22:10:30.257Z</published>
+    <updated>2007-07-11T21:46:35.000Z</updated>
+    <title>My Primary Calendar</title>
+    <summary type='text'>A primary calendar is created by default for each Google Calendar user.</summary>
+    <link rel='alternate' type='application/atom+xml' href='https://www.google.com/calendar/feeds/user%40gmail.com/private/full' />
+    <link rel='http://schemas.google.com/gCal/2005#eventFeed' type='application/atom+xml' href='https://www.google.com/calendar/feeds/user%40gmail.com/private/full' />
+    <link rel='http://schemas.google.com/acl/2007#accessControlList' type='application/atom+xml' href='https://www.google.com/calendar/feeds/user%40gmail.com/acl/full' />
+    <link rel='self' type='application/atom+xml' href='https://www.google.com/calendar/feeds/default/allcalendars/full/user%40gmail.com' />
+    <link rel='edit' type='application/atom+xml' href='https://www.google.com/calendar/feeds/default/allcalendars/full/user%40gmail.com' />
+    <author>
+      <name>Coach</name>
+      <email>user@gmail.com</email>
+    </author>
+    <gCal:timezone value='America/Los_Angeles' />
+    <gCal:hidden value='false' />
+    <gCal:color value='#2952A3' />
+    <gCal:selected value='true' />
+    <gCal:accesslevel value='owner' />
+    <gd:where valueString='Mountain View' />
+  </entry>
+  <entry gd:etag='W/"Ck4GRH4-eSp7ImA9WxRVGUo."'>
+    <id>http://www.google.com/calendar/feeds/default/allcalendars/full/rf1c66uld6dgk2t5lh43svev6g%40group.calendar.google.com</id>
+    <published>2007-07-11T22:10:30.258Z</published>
+    <updated>2007-07-11T21:50:15.000Z</updated>
+    <title>Little Giants</title>
+    <summary type='text'>This calendar contains practice times and this season's Little League game schedule. Go Little Giants!</summary>
+    <link rel='alternate' type='application/atom+xml' href='https://www.google.com/calendar/feeds/rf1c66uld6dgk2t5lh43svev6g%40group.calendar.google.com/private/full'/>
+    <link rel='http://schemas.google.com/gCal/2005#eventFeed' type='application/atom+xml' href='https://www.google.com/calendar/feeds/rf1c66uld6dgk2t5lh43svev6g%40group.calendar.google.com/private/full'/>
+    <link rel='http://schemas.google.com/acl/2007#accessControlList' type='application/atom+xml' href='https://www.google.com/calendar/feeds/rf1c66uld6dgk2t5lh43svev6g%40group.calendar.google.com/acl/full'/>
+    <link rel='self' type='application/atom+xml' href='https://www.google.com/calendar/feeds/default/allcalendars/full/rf1c66uld6dgk2t5lh43svev6g%40group.calendar.google.com'/>
+    <link rel='edit' type='application/atom+xml' href='https://www.google.com/calendar/feeds/default/allcalendars/full/rf1c66uld6dgk2t5lh43svev6g%40group.calendar.google.com'/>
+    <author>
+      <name>Little Giants</name>
+    </author>
+    <gCal:timezone value='America/Los_Angeles' />
+    <gCal:hidden value='false' />
+    <gCal:color value='#5A6986' />
+    <gCal:selected value='false' />
+    <gCal:accesslevel value='owner' />
+    <gd:where valueString='San Francisco' />
+  </entry>
+  <entry gd:etag='W/"C0cEQnkyeip7ImA9WxRVGUo."'>
+    <id>http://www.google.com/calendar/feeds/default/allcalendars/full/c4o4i7m2lbamc4k26sc2vokh5g%40group.calendar.google.com</id>
+    <published>2007-07-11T22:10:30.297Z</published>
+    <updated>2007-06-05T09:38:50.000Z</updated>
+    <title>Google Doodles</title>
+    <summary type='text'/>
+    <link rel='alternate' type='application/atom+xml' href='https://www.google.com/calendar/feeds/c4o4i7m2lbamc4k26sc2vokh5g%40group.calendar.google.com/private/full'/>
+    <link rel='http://schemas.google.com/gCal/2005#eventFeed' type='application/atom+xml' href='https://www.google.com/calendar/feeds/c4o4i7m2lbamc4k26sc2vokh5g%40group.calendar.google.com/private/full'/>
+    <link rel='self' type='application/atom+xml' href='https://www.google.com/calendar/feeds/default/allcalendars/full/c4o4i7m2lbamc4k26sc2vokh5g%40group.calendar.google.com'/>
+    <link rel='edit' type='application/atom+xml' href='https://www.google.com/calendar/feeds/default/allcalendars/full/c4o4i7m2lbamc4k26sc2vokh5g%40group.calendar.google.com'/>
+    <author>
+      <name>Google Doodles</name>
+    </author>
+    <gCal:timezone value='Etc/GMT' />
+    <gCal:hidden value='false' />
+    <gCal:color value='#5229A3' />
+    <gCal:selected value='false' />
+    <gCal:accesslevel value='read' />
+    <gd:where valueString='' />
+  </entry>
+</feed>

--- a/test/test_google_calendar.rb
+++ b/test/test_google_calendar.rb
@@ -66,6 +66,40 @@ class TestGoogleCalendar < Test::Unit::TestCase
                 :auth_url => "https://www.google.com/accounts/ClientLogin/waffles"
               )
             end
+          end
+
+          should "login properly with a calendar" do
+            assert_nothing_thrown do
+              cal = Calendar.new(:username => 'some.one@gmail.com', :password => 'super-secret',
+              :calendar => "Little Giants")
+
+              #mock calendar list request
+              calendar_uri = mock("get calendar uri")
+              Addressable::URI.expects(:parse).with("https://www.google.com/calendar/feeds/default/allcalendars/full").once.returns(calendar_uri)
+              Connection.any_instance.expects(:send).with(calendar_uri, :get).once.returns(mock("response", :body => get_mock_body('list_calendars.xml')))
+
+              #mock events list request
+              events_uri = mock("get events uri")
+              Addressable::URI.expects(:parse).with("https://www.google.com/calendar/feeds/rf1c66uld6dgk2t5lh43svev6g%40group.calendar.google.com/private/full").once.returns(events_uri)
+              Connection.any_instance.expects(:send).with(events_uri, :get).once.returns(mock("response", :body => get_mock_body('events.xml')))
+
+              cal.events
+            end
+          end
+
+          should "catch login with invalid calendar" do
+
+            assert_raise(InvalidCalendar) do
+              cal = Calendar.new(:username => 'some.one@gmail.com', :password => 'super-secret',
+              :calendar => "invalid calendar")
+
+              #mock calendar list request
+              calendar_uri = mock("get calendar uri")
+              Addressable::URI.expects(:parse).with("https://www.google.com/calendar/feeds/default/allcalendars/full").once.returns(calendar_uri)
+              Connection.any_instance.expects(:send).with(calendar_uri, :get).once.returns(mock("response", :body => get_mock_body('list_calendars.xml')))
+
+              cal.events
+            end
           end               
 
     end # login context


### PR DESCRIPTION
Changed :calendar option to be able to specify a calendar name.

When calendar is a name like "my personal calendar" (not containing any @):

```
cal = Google::Calendar.new :username => "blabla", :password => "bar", :calendar => "my personal calendar"
cal.events
# fetch user's all calendar.
# find calendar title corresponding to :calendar.
# get event feed url from calendar.
# fetch events from this url.
```

When calendar is a userID like "joe@gmail.com" (containing @) :

```
cal = Google::Calendar.new :username => "blabla", :password => "bar", :calendar => "joe@gmail.com"
cal.events
# construct event feed url from default feed url.
# fetch events from this url.
```
