### PR TITLE
Add parameters requesting google to expand recurring events

### DIFF
--- a/lib/google/calendar.rb
+++ b/lib/google/calendar.rb
@@ -158,6 +158,10 @@ module Google
                                    :auth_url => auth_url)
       self
     end
+    
+    def display_color
+      calendar_data.xpath("//entry[title='#{@calendar}']/color/@value").first.value
+    end
 
     protected
 
@@ -188,14 +192,20 @@ module Google
     #
     def events_url
       if @calendar and !@calendar.include?("@")
-         xml = @connection.send(Addressable::URI.parse("https://www.google.com/calendar/feeds/default/allcalendars/full"), :get)
-         doc = Nokogiri::XML(xml.body)
-         doc.remove_namespaces!
-         link = doc.xpath("//entry[title='#{@calendar}']/link[contains(@rel, '#eventFeed')]/@href").to_s
+         link = calendar_data.xpath("//entry[title='#{@calendar}']/link[contains(@rel, '#eventFeed')]/@href").to_s
          link.empty? ? raise(Google::InvalidCalendar) : link
        else
          "https://www.google.com/calendar/feeds/#{calendar_id}/private/full"
       end
+    end
+    
+    def calendar_data
+      unless @calendar_data
+        xml = @connection.send(Addressable::URI.parse("https://www.google.com/calendar/feeds/default/allcalendars/full"), :get)
+        @calendar_data = Nokogiri::XML(xml.body)
+        @calendar_data.remove_namespaces!
+      end
+      @calendar_data
     end
 
     def setup_event(event) #:nodoc:

--- a/lib/google/event.rb
+++ b/lib/google/event.rb
@@ -36,6 +36,7 @@ module Google
       @where = params[:where]
       @start_time = params[:start_time]
       @end_time = params[:end_time]
+      self.all_day= params[:all_day] if params[:all_day]
       @calendar = params[:calendar]
       @raw_xml = params[:raw_xml]
       @quickadd = params[:quickadd]
@@ -77,6 +78,14 @@ module Google
     #
     def all_day?
       duration == 24 * 60 * 60 # Exactly one day
+    end
+    
+    def all_day=(time)
+      if time.class == String
+        time = Time.parse(time)
+      end
+      @start_time = time.strftime("%Y-%m-%d")
+      @end_time = (time + 24*60*60).strftime("%Y-%m-%d")
     end
     
     # Duration in seconds

--- a/test/test_google_calendar.rb
+++ b/test/test_google_calendar.rb
@@ -232,6 +232,24 @@ class TestGoogleCalendar < Test::Unit::TestCase
         end
       end
     end
+    
+    context "#all_day=" do
+      context "sets the start and end time to the appropriate values for an all day event on that day" do
+        should "set the start time" do
+          @event = Event.new :all_day => Time.parse("2012-05-02 12:24")
+          assert_equal @event.start_time, "2012-05-02"
+        end
+        should "set the end time" do
+          @event = Event.new :all_day => Time.parse("2012-05-02 12:24")
+          assert_equal @event.end_time, "2012-05-03"
+        end
+        should "be able to handle strings" do
+          @event = Event.new :all_day => "2012-05-02 12:24"
+          assert_equal @event.start_time, "2012-05-02"
+          assert_equal @event.end_time, "2012-05-03"
+        end
+      end
+    end
   end
 
   def test_https_extension


### PR DESCRIPTION
Hi Steve,
     Thanks a bunch for this work... I am really glad there's already a ruby api to gcal.  Wanted to suggest the attached change.  I found that event.rb chokes on recurring events while parsing the XML, and when I looked at the recurrence data given there, I could see why.  It's not the easiest thing to parse -- so without going back to the RFC I thought it would be easy to just have Google expand recurrences.
     The only place I could think of to do this is in find_events_in_range, which is perfect for my application.  Not sure exactly how to work it in to the other query methods but I don't really need that since a month's worth of data will render out the views I'm interested in.

Also, an all_day? method for events seems useful.

Again thanks and if this change makes sense to you I'd appreciate a new version of the gem out on rubygems so I can delete my fork.
TPG
