### PR TITLE
max_results parameter

### DIFF
--- a/lib/google/calendar.rb
+++ b/lib/google/calendar.rb
@@ -76,10 +76,13 @@ module Google
     #   a single event if only one found.
     #   an array of events if many found.
     #
-    def find_events_in_range(start_min, start_max)
+    def find_events_in_range(start_min, start_max,options = {})
+	options[:max_results] ||=  25
       formatted_start_min = start_min.strftime("%Y-%m-%dT%H:%M:%S")
       formatted_start_max = start_max.strftime("%Y-%m-%dT%H:%M:%S")
-      event_lookup("?start-min=#{formatted_start_min}&start-max=#{formatted_start_max}&recurrence-expansion-start=#{formatted_start_min}&recurrence-expansion-end=#{formatted_start_max}")
+      query = "?start-min=#{formatted_start_min}&start-max=#{formatted_start_max}&recurrence-expansion-start=#{formatted_start_min}&recurrence-expansion-end=#{formatted_start_max}"
+	query = "#{query}&max-results=#{options[:max_results]}"
+      event_lookup(query)
     end
 
     # Attempts to find the event specified by the id

--- a/test/test_google_calendar.rb
+++ b/test/test_google_calendar.rb
@@ -128,7 +128,7 @@ class TestGoogleCalendar < Test::Unit::TestCase
       should "find events in range" do
         start_min = DateTime.new(2011, 2, 1, 11, 1, 1)
         start_max = DateTime.new(2011, 2, 28, 23, 59, 59)
-        @calendar.expects(:event_lookup).with('?start-min=2011-02-01T11:01:01&start-max=2011-02-28T23:59:59&recurrence-expansion-start=2011-02-01T11:01:01&recurrence-expansion-end=2011-02-28T23:59:59')
+        @calendar.expects(:event_lookup).with('?start-min=2011-02-01T11:01:01&start-max=2011-02-28T23:59:59&recurrence-expansion-start=2011-02-01T11:01:01&recurrence-expansion-end=2011-02-28T23:59:59&max-results=25')
         events = @calendar.find_events_in_range(start_min, start_max)
       end
 


### PR DESCRIPTION
Iv added max results parameter to the find_events_in_range method in order to be able to fetch more then 25 results (see https://developers.google.com/google-apps/calendar/v2/reference#Parameters) 
