### PR TITLE
fixed issue9 concerning ampersands

### DIFF
--- a/lib/google/calendar.rb
+++ b/lib/google/calendar.rb
@@ -213,7 +213,12 @@ module Google
 
     def setup_event(event) #:nodoc:
       event.calendar = self
-       yield(event) if block_given?
+      if block_given?
+      	yield(event)
+	event.title = event.title.encode(:xml => :text) if event.title
+	event.content = event.content.encode(:xml => :text) if event.content
+	event.where = event.where.encode(:xml => :text) if event.where
+      end
       event.save
       event
     end

--- a/test/test_google_calendar.rb
+++ b/test/test_google_calendar.rb
@@ -168,6 +168,22 @@ class TestGoogleCalendar < Test::Unit::TestCase
         assert_equal event.content, "movie tomorrow 23:00 at AMC Van Ness"
       end
 
+      should "format create event with ampersand correctly" do
+	@http_mock.stubs(:body).returns( get_mock_body("create_event.xml") )
+	
+	event = @calendar.create_event do |e|
+	  e.title = 'New Event with &'
+	  e.start_time = Time.now + (60 * 60)
+	  e.end_time = Time.now + (60 * 60 * 2)
+	  e.content = "A new event with &"
+	  e.where = "Joe's House & Backyard"
+	end
+	
+	assert_equal event.title, 'New Event with &amp;'
+	assert_equal event.content, 'A new event with &amp;'
+	assert_equal event.where, "Joe's House &amp; Backyard"
+      end
+
       should "format to_s properly" do
         @http_mock.stubs(:body).returns( get_mock_body("query_events.xml") )
         event = @calendar.find_events('Test')


### PR DESCRIPTION
This is a commit which fixes [issue #9](https://github.com/northworld/google_calendar/issues/9) concerning the unescaped ampersands (&) in event titles. This is my first time writing tests and creating a pull request, so let me know if I did anything wrong, and I'll try to fix it.
