### PR TITLE
Format start_min & start_max to support time zone

### DIFF
--- a/lib/google/calendar.rb
+++ b/lib/google/calendar.rb
@@ -1,4 +1,5 @@
 require 'nokogiri'
+require 'cgi'
 
 module Google
 
@@ -79,8 +80,8 @@ module Google
     def find_events_in_range(start_min, start_max,options = {})
       options[:max_results] ||=  25
       options[:order_by] ||= 'lastmodified' # other option is 'starttime'
-      formatted_start_min = start_min.strftime("%Y-%m-%dT%H:%M:%S")
-      formatted_start_max = start_max.strftime("%Y-%m-%dT%H:%M:%S")
+      formatted_start_min = CGI::escape(start_min.strftime("%FT%T%:z"))
+      formatted_start_max = CGI::escape(start_min.strftime("%FT%T%:z"))
       query = "?start-min=#{formatted_start_min}&start-max=#{formatted_start_max}&recurrence-expansion-start=#{formatted_start_min}&recurrence-expansion-end=#{formatted_start_max}"
       query = "#{query}&orderby=#{options[:order_by]}&max-results=#{options[:max_results]}"
       event_lookup(query)


### PR DESCRIPTION
It working for me. But escaping could be done more elegant I think, but anyway.
