### PR TITLE
minor update to event.rb to allow all_day? to process @start_time to contain a time object

### DIFF
--- a/lib/google/event.rb
+++ b/lib/google/event.rb
@@ -83,7 +83,7 @@ module Google
     # Returns whether the Event is an all-day event, based on whether the event starts at the beginning and ends at the end of the day.
     #
     def all_day?
-      time = Time.parse(@start_time)
+      time = (@start_time.is_a?  String) ? Time.parse(@start_time) : @start_time.dup.utc
       duration % (24 * 60 * 60) == 0 && time == Time.local(time.year,time.month,time.day)
     end
 


### PR DESCRIPTION
Please bear with me before this is my first time submitting a patch, through github etc

Bug description : event.rb : all_day?  calls time.parse( @start_time ) if @start_time is a Time object this causes an exception in time.parse.

in my application this was generating crashes like this...
/home/jlovick/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/time.rb:325:in `_parse': no implicit conversion of Time into String (TypeError)
        from /home/jlovick/.rvm/rubies/ruby-2.0.0-p0/lib/ruby/2.0.0/time.rb:325:in`parse'
        from /home/jlovick/.rvm/gems/ruby-2.0.0-p0/gems/google_calendar-0.3.1/lib/google/event.rb:88:in `all_day?'

its arguable that the core time.rb shouldn't have this behavior, but i think its more practical to fix here.  

resolution : Change to allow all_day? to cope with a time object as well as a string
this is actually the same approach as taken in end_time, about 5 lines above this change.
