### PR TITLE
Fixed parameters for saving All-day events

### DIFF
--- a/lib/google/event.rb
+++ b/lib/google/event.rb
@@ -183,10 +183,12 @@ module Google
         \"description\": \"#{description}\", 
         \"location\": \"#{location}\", 
         \"start\": {
-          \"dateTime\": \"#{start_time}\"
+          #{("\"date\": \"" + start_time+ "\"" )if all_day?}
+          #{("\"dateTime\": \"" + start_time + "\"" )if !all_day?}
         },
         \"end\": {
-          \"dateTime\": \"#{end_time}\"
+          #{("\"date\": \"" + end_time + "\"" )if all_day?}
+          #{("\"dateTime\": \"" + end_time + "\"" )if !all_day?}
         },
         #{attendees_json}
         \"reminders\": {


### PR DESCRIPTION
#### For all_day events the google api v3 requires date parameter 
```javascript
"start": {
  "date": "startDate",
},
"end": {
  "date": "endDate",
},
```
[Google API Reference - All Day] (https://developers.google.com/google-apps/calendar/concepts#all_day_events)

#### whereas for timed events the google api v3 requires dateTime parameter
```javascript
"start": {
  "dateTime": "startTime",
  # Optional
  "timeZone": "America/Los_Angeles"
},
"end": {
  "dateTime": "endTime",
  # Optional
  "timeZone": "America/Los_Angeles"
},
```
[Google API Reference - Timed] (https://developers.google.com/google-apps/calendar/concepts#timed_events)