### PR TITLE
Recurring events

### DIFF
--- a/lib/google/calendar.rb
+++ b/lib/google/calendar.rb
@@ -202,9 +202,6 @@ module Google
       method = event.new_event? ? :post : :put
       body = event.use_quickadd? ? nil : event.to_json
 
-      # p event         # fuck
-      # p event.to_json # fuck
-
       query_string =  if event.use_quickadd?
         "/quickAdd?text=#{event.title}"
       elsif event.new_event?

--- a/lib/google/event.rb
+++ b/lib/google/event.rb
@@ -281,9 +281,7 @@ module Google
     # JSON representation of recurrence rules for repeating events
     #
     def recurrence_json
-      # puts "converting to json" # fuck
       return unless @recurrence && @recurrence[:freq]
-      # puts "did not return"     # fuck
 
       @recurrence[:until] = @recurrence[:until].strftime('%Y%m%dT%H%M%SZ') if @recurrence[:until]
       rrule = "RRULE:" + @recurrence.collect { |k,v| "#{k}=#{v}" }.join(';').upcase
@@ -337,7 +335,6 @@ module Google
     # Create a new event from a google 'entry'
     #
     def self.new_from_feed(e, calendar) #:nodoc:
-      # p e   # fuck
       Event.new(:id           => e['id'],
                 :calendar     => calendar,
                 :status       => e['status'],

--- a/lib/google_calendar.rb
+++ b/lib/google_calendar.rb
@@ -1,4 +1,4 @@
-module Google   # fuck
+module Google
   require 'google/errors'
   require 'google/calendar'
   require 'google/connection'


### PR DESCRIPTION
Added support for recurring events.

Works like this:

```
event = cal.create_event do |e|
  e.title = 'Work-day Event'
  e.start_time = Time.now
  e.end_time = Time.now + (60 * 60) # seconds * min
  e.recurrence = {freq: "weekly", byday: "mo,tu,we,th,fr"} 
end
```

I created some tests as well. If you have any comments please let me know.
