### PR TITLE
Add basic support for Calendar Lists

### DIFF
--- a/lib/google/calendar.rb
+++ b/lib/google/calendar.rb
@@ -26,15 +26,13 @@ module Google
     #                      :redirect_url => "urn:ietf:wg:oauth:2.0:oob" # this is what Google uses for 'applications'
     #                     )
     #
-    def initialize(params={})
-      options = {
+    def initialize(params={}, connection=nil)
+      @connection = connection || Connection.new(
         :client_id => params[:client_id],
         :client_secret => params[:client_secret],
         :refresh_token => params[:refresh_token],
         :redirect_url => params[:redirect_url]
-      }
-
-      @connection = Connection.new options
+      )
 
       calendar_id = params[:calendar]
       # raise CalendarIDMissing unless calendar_id

--- a/lib/google/calendar.rb
+++ b/lib/google/calendar.rb
@@ -6,7 +6,7 @@ module Google
   #
   class Calendar
 
-    attr_reader :connection
+    attr_reader :id, :connection
 
     #
     # Setup and connect to the specified Google Calendar.
@@ -34,9 +34,8 @@ module Google
         :redirect_url => params[:redirect_url]
       )
 
-      calendar_id = params[:calendar]
-      # raise CalendarIDMissing unless calendar_id
-      @events_base_path = "/calendars/#{CGI::escape calendar_id}/events"
+      @id = params[:calendar]
+      # raise CalendarIDMissing unless @id
     end
 
     #
@@ -271,7 +270,7 @@ module Google
     # Wraps the `send` method. Send an event related request to Google.
     #
     def send_events_request(path_and_query_string, method, content = '')
-      @connection.send(@events_base_path + path_and_query_string, method, content)
+      @connection.send("/calendars/#{CGI::escape @id}/events#{path_and_query_string}", method, content)
     end
   end
 

--- a/lib/google/calendar.rb
+++ b/lib/google/calendar.rb
@@ -20,10 +20,10 @@ module Google
     # See Readme.rdoc or readme_code.rb for an explication on the OAuth2 authorization process.
     #
     # ==== Example
-    # Google::Calendar.new(:client_id => YOUR_CLIENT_ID, 
+    # Google::Calendar.new(:client_id => YOUR_CLIENT_ID,
     #                      :client_secret => YOUR_SECRET,
     #                      :calendar => YOUR_CALENDAR_ID,
-    #                      :redirect_url => "urn:ietf:wg:oauth:2.0:oob" # this is what Google uses for 'applications' 
+    #                      :redirect_url => "urn:ietf:wg:oauth:2.0:oob" # this is what Google uses for 'applications'
     #                     )
     #
     def initialize(params={})
@@ -95,8 +95,8 @@ module Google
     end
 
     #
-    # This is equivalent to running a search in the Google calendar web application.  
-    # Google does not provide a way to specify what attributes you would like to 
+    # This is equivalent to running a search in the Google calendar web application.
+    # Google does not provide a way to specify what attributes you would like to
     # search (i.e. title), by default it searches everything.
     # If you would like to find specific attribute value (i.e. title=Picnic), run a query
     # and parse the results.
@@ -124,7 +124,7 @@ module Google
     #   an array with one element if only one found.
     #   an array of events if many found.
     #
-    def find_events_in_range(start_min, start_max, options = {})     
+    def find_events_in_range(start_min, start_max, options = {})
       formatted_start_min = encode_time(start_min)
       formatted_start_max = encode_time(start_max)
       query = "?timeMin=#{formatted_start_min}&timeMax=#{formatted_start_max}#{parse_options(options)}"

--- a/lib/google/calendar_list.rb
+++ b/lib/google/calendar_list.rb
@@ -35,7 +35,7 @@ module Google
 
       return nil if response.status != 200 || response.body.empty?
 
-      CalendarListEntry.build_from_google_feed(JSON.parse(response.body))
+      CalendarListEntry.build_from_google_feed(JSON.parse(response.body), @connection)
     end
 
   end

--- a/lib/google/calendar_list.rb
+++ b/lib/google/calendar_list.rb
@@ -1,0 +1,41 @@
+module Google
+
+  #
+  # CalendarList is the main object you use to find Calendars.
+  #
+  class CalendarList
+
+    #
+    # Setup and connect to the user's list of Google Calendars.
+    #
+    # The +params+ parameter accepts
+    # * :client_id => the client ID that you received from Google after registering your application with them (https://console.developers.google.com/). REQUIRED
+    # * :client_secret => the client secret you received from Google after registering your application with them. REQUIRED
+    # * :redirect_url => the url where your users will be redirected to after they have successfully permitted access to their calendars. Use 'urn:ietf:wg:oauth:2.0:oob' if you are using an 'application'" REQUIRED
+    # * :refresh_token => if a user has already given you access to their calendars, you can specify their refresh token here and you will be 'logged on' automatically (i.e. they don't need to authorize access again). OPTIONAL
+    #
+    # See Readme.rdoc or readme_code.rb for an explication on the OAuth2 authorization process.
+    #
+    def initialize(params)
+      @connection = Connection.new(
+        :client_id => params[:client_id],
+        :client_secret => params[:client_secret],
+        :refresh_token => params[:refresh_token],
+        :redirect_url => params[:redirect_url]
+      )
+    end
+
+    #
+    # Find all entries on the user's calendar list. Returns an array of CalendarListEntry objects.
+    #
+    def fetch_entries
+      response = @connection.send("/users/me/calendarList", :get)
+
+      return nil if response.status != 200 || response.body.empty?
+
+      CalendarListEntry.build_from_google_feed(JSON.parse(response.body))
+    end
+
+  end
+
+end

--- a/lib/google/calendar_list.rb
+++ b/lib/google/calendar_list.rb
@@ -5,6 +5,8 @@ module Google
   #
   class CalendarList
 
+    attr_reader :connection
+
     #
     # Setup and connect to the user's list of Google Calendars.
     #
@@ -16,8 +18,8 @@ module Google
     #
     # See Readme.rdoc or readme_code.rb for an explication on the OAuth2 authorization process.
     #
-    def initialize(params)
-      @connection = Connection.new(
+    def initialize(params={}, connection=nil)
+      @connection = connection || Connection.new(
         :client_id => params[:client_id],
         :client_secret => params[:client_secret],
         :refresh_token => params[:refresh_token],

--- a/lib/google/calendar_list_entry.rb
+++ b/lib/google/calendar_list_entry.rb
@@ -14,20 +14,25 @@ module Google
   # * +primary?+ - Whether the calendar is the primary calendar of the authenticated user. Read-only.
   #
   class CalendarListEntry
-    attr_reader :id, :summary, :time_zone, :access_role, :primary
+    attr_reader :id, :summary, :time_zone, :access_role, :primary, :connection
     alias_method :primary?, :primary
 
-    def initialize(params)
+    def initialize(params, connection)
       @id = params['id']
       @summary = params['summary']
       @time_zone = params['timeZone']
       @access_role = params['accessRole']
       @primary = params.fetch('primary', false)
+      @connection = connection
     end
 
-    def self.build_from_google_feed(response)
+    def to_calendar
+      Calendar.new({:calendar => @id}, @connection)
+    end
+
+    def self.build_from_google_feed(response, connection)
       items = response['items']
-      items.collect { |item| CalendarListEntry.new(item) }
+      items.collect { |item| CalendarListEntry.new(item, connection) }
     end
 
   end

--- a/lib/google/calendar_list_entry.rb
+++ b/lib/google/calendar_list_entry.rb
@@ -1,0 +1,35 @@
+module Google
+
+  #
+  # Represents a Google Calendar List Entry
+  #
+  # See https://developers.google.com/google-apps/calendar/v3/reference/calendarList#resource
+  #
+  # === Attributes
+  #
+  # * +id+ - The Google assigned id of the calendar. Read only.
+  # * +summary+ - Title of the calendar. Read-only.
+  # * +time_zone+ - The time zone of the calendar. Optional. Read-only.
+  # * +access_role+ - The effective access role that the authenticated user has on the calendar. Read-only.
+  # * +primary?+ - Whether the calendar is the primary calendar of the authenticated user. Read-only.
+  #
+  class CalendarListEntry
+    attr_reader :id, :summary, :time_zone, :access_role, :primary
+    alias_method :primary?, :primary
+
+    def initialize(params)
+      @id = params['id']
+      @summary = params['summary']
+      @time_zone = params['timeZone']
+      @access_role = params['accessRole']
+      @primary = params.fetch('primary', false)
+    end
+
+    def self.build_from_google_feed(response)
+      items = response['items']
+      items.collect { |item| CalendarListEntry.new(item) }
+    end
+
+  end
+
+end

--- a/lib/google/connection.rb
+++ b/lib/google/connection.rb
@@ -33,11 +33,6 @@ module Google
         :scope => "https://www.googleapis.com/auth/calendar"
       )
 
-      calendar_id = params[:calendar_id]
-
-      # raise CalenarIDMissing unless calendar_id
-      @events_url = "#{BASE_URI}/calendars/#{CGI::escape calendar_id}/events"
-
       # try to get an access token if possible.
       if params[:refresh_token]
         @client.refresh_token = params[:refresh_token]
@@ -97,7 +92,9 @@ module Google
     #
     # Send a request to google.
     #
-    def send(uri, method, content = '')
+    def send(path, method, content = '')
+
+      uri = BASE_URI + path
 
       response = @client.fetch_protected_resource(
         :uri => uri,
@@ -109,13 +106,6 @@ module Google
       check_for_errors(response)
 
       return response
-    end
-
-    #
-    # Wraps the `send` method. Send an event related request to Google.
-    #
-    def send_events_request(path_and_query_string, method, content = '')
-      send(@events_url + path_and_query_string, method, content)
     end
 
     protected

--- a/lib/google/connection.rb
+++ b/lib/google/connection.rb
@@ -114,7 +114,7 @@ module Google
     # Utility method to centralize the process of getting an access token.
     #
     def self.get_new_access_token(client) #:nodoc:
-      begin 
+      begin
         client.fetch_access_token!
       rescue Signet::AuthorizationError
         raise HTTPAuthorizationFailed

--- a/lib/google/event.rb
+++ b/lib/google/event.rb
@@ -15,7 +15,7 @@ module Google
   # * +location+ - The location of the event. Read Write.
   # * +start_time+ - The start time of the event (Time object, defaults to now). Read Write.
   # * +end_time+ - The end time of the event (Time object, defaults to one hour from now).  Read Write.
-  # * +recurrence+ - A hash containing recurrence info for repeating events. Read write. 
+  # * +recurrence+ - A hash containing recurrence info for repeating events. Read write.
   # * +calendar+ - What calendar the event belongs to. Read Write.
   # * +all_day + - Does the event run all day. Read Write.
   # * +quickadd+ - A string that Google parses when setting up a new event.  If set and then saved it will take priority over any attributes you have set. Read Write.
@@ -126,14 +126,14 @@ module Google
     # Stores reminders for this event. Multiple reminders are allowed.
     #
     # Examples
-    #  
+    #
     # event = cal.create_event do |e|
     #   e.title = 'Some Event'
     #   e.start_time = Time.now + (60 * 10)
     #   e.end_time = Time.now + (60 * 60) # seconds * min
-    #   e.reminders = { 'useDefault'  => false, 'overrides' => [{method: 'email', minutes: 4}, {method: 'popup', minutes: 60}, {method: 'sms', minutes: 30}]} 
+    #   e.reminders = { 'useDefault'  => false, 'overrides' => [{method: 'email', minutes: 4}, {method: 'popup', minutes: 60}, {method: 'sms', minutes: 30}]}
     # end
-    # 
+    #
     # event = Event.new :start_time => "2012-03-31", :end_time => "2012-04-03", :reminders => { 'useDefault'  => false, 'overrides' => [{'minutes' => 10, 'method' => "popup"}]}
     #
     def reminders
@@ -149,8 +149,8 @@ module Google
     # :until => Time class, until when the event should occur                   OPTIONAL
     # :interval => how often should the event occur (every "2" weeks, ...)      OPTIONAL
     # :byday => if frequence is "weekly", contains ordered (starting with       OPTIONAL
-    #             Sunday)comma separated abbreviations of days the event 
-    #             should occur on ("su,mo,th")                                  
+    #             Sunday)comma separated abbreviations of days the event
+    #             should occur on ("su,mo,th")
     #           if frequence is "monthly", can specify which day of month
     #             the event should occur on ("2mo" - second Monday, "-1th" - last Thursday,
     #             allowed indices are 1,2,3,4,-1)
@@ -162,14 +162,14 @@ module Google
     #   e.title = 'Work-day Event'
     #   e.start_time = Time.now
     #   e.end_time = Time.now + (60 * 60) # seconds * min
-    #   e.recurrence = {freq: "weekly", byday: "mo,tu,we,th,fr"} 
+    #   e.recurrence = {freq: "weekly", byday: "mo,tu,we,th,fr"}
     # end
     #
     def recurrence
       @recurrence ||= {}
     end
 
-    # 
+    #
     # Utility method that simplifies setting the transparency of an event.
     # You can pass true or false.  Defaults to transparent.
     #
@@ -192,7 +192,7 @@ module Google
     #
     # Returns true if the event is opaque otherwise returns false.
     # Opaque events block time on a calendar.
-    # 
+    #
     def opaque?
       @transparency == "opaque"
     end
@@ -211,8 +211,8 @@ module Google
     def to_json
       "{
         \"summary\": \"#{title}\",
-        \"description\": \"#{description}\", 
-        \"location\": \"#{location}\", 
+        \"description\": \"#{description}\",
+        \"location\": \"#{location}\",
         \"start\": {
           \"dateTime\": \"#{start_time}\"
           #{timezone_needed? ? local_timezone_json : ''}
@@ -228,7 +228,7 @@ module Google
         }
       }"
     end
-    
+
     #
     # JSON representation of attendees
     #
@@ -237,7 +237,7 @@ module Google
 
       attendees = @attendees.map do |attendee|
         "{
-          \"displayName\": \"#{attendee['displayName']}\", 
+          \"displayName\": \"#{attendee['displayName']}\",
           \"email\": \"#{attendee['email']}\",
           \"responseStatus\": \"#{attendee['responseStatus']}\"
         }"
@@ -250,10 +250,10 @@ module Google
     # JSON representation of a reminder
     #
     def reminders_json
-      if reminders && reminders.is_a?(Hash) && reminders['overrides'] 
+      if reminders && reminders.is_a?(Hash) && reminders['overrides']
         overrides = reminders['overrides'].map do |reminder|
           "{
-            \"method\": \"#{reminder['method']}\", 
+            \"method\": \"#{reminder['method']}\",
             \"minutes\": #{reminder['minutes']}
           }"
         end.join(",\n")
@@ -359,7 +359,7 @@ module Google
     #
     def self.parse_recurrence_rule(recurrence_entry)
       return {} unless recurrence_entry && recurrence_entry != []
-      
+
       rrule = recurrence_entry[0].sub('RRULE:', '')
       rhash = Hash[*rrule.downcase.split(/[=;]/)]
 
@@ -384,7 +384,7 @@ module Google
         Time.parse(time_hash['dateTime']).utc
       else
         Time.now.utc
-      end      
+      end
     end
 
     #

--- a/lib/google_calendar.rb
+++ b/lib/google_calendar.rb
@@ -1,6 +1,8 @@
 module Google
   require 'google/errors'
   require 'google/calendar'
+  require 'google/calendar_list'
+  require 'google/calendar_list_entry'
   require 'google/connection'
   require 'google/event'
 end

--- a/test/helper.rb
+++ b/test/helper.rb
@@ -14,7 +14,7 @@ rescue Bundler::BundlerError => e
 end
 
 require "minitest/autorun"
-require 'minitest/reporters' 
+require 'minitest/reporters'
 require 'shoulda/context'
 require 'mocha/setup'
 require 'faraday'

--- a/test/mocks/find_calendar_list.json
+++ b/test/mocks/find_calendar_list.json
@@ -1,0 +1,69 @@
+{
+  "kind": "calendar#calendarList",
+  "etag": "\"1420633154361000\"",
+  "nextSyncToken": "00001420633154361000",
+  "items": [
+    {
+      "kind": "calendar#calendarListEntry",
+      "etag": "\"1420564622795000\"",
+      "id": "initech.com_ed493d0a9b46ea46c3a0d48611ce@resource.calendar.google.com",
+      "summary": "Small cubicle",
+      "timeZone": "America/Los_Angeles",
+      "colorId": "2",
+      "backgroundColor": "#d06b64",
+      "foregroundColor": "#000000",
+      "accessRole": "owner",
+      "defaultReminders": []
+    },
+    {
+      "kind": "calendar#calendarListEntry",
+      "etag": "\"1420564132697000\"",
+      "id": "initech.com_db18a4e59c230a5cc5d2b069a30f@resource.calendar.google.com",
+      "summary": "Large cubicle",
+      "timeZone": "America/Los_Angeles",
+      "colorId": "3",
+      "backgroundColor": "#f83a22",
+      "foregroundColor": "#000000",
+      "accessRole": "reader",
+      "defaultReminders": []
+    },
+    {
+      "kind": "calendar#calendarListEntry",
+      "etag": "\"1420564622222000\"",
+      "id": "bob@initech.com",
+      "summary": "Bob's Calendar",
+      "timeZone": "Europe/London",
+      "colorId": "17",
+      "backgroundColor": "#9a9cff",
+      "foregroundColor": "#000000",
+      "accessRole": "owner",
+      "defaultReminders": [
+        {
+          "method": "popup",
+          "minutes": 10
+        }
+      ],
+      "notificationSettings": {
+        "notifications": [
+          {
+            "type": "eventCreation",
+            "method": "email"
+          },
+          {
+            "type": "eventChange",
+            "method": "email"
+          },
+          {
+            "type": "eventCancellation",
+            "method": "email"
+          },
+          {
+            "type": "eventResponse",
+            "method": "email"
+          }
+        ]
+      },
+      "primary": true
+    }
+  ]
+}

--- a/test/test_google_calendar.rb
+++ b/test/test_google_calendar.rb
@@ -56,6 +56,15 @@ class TestGoogleCalendar < Minitest::Test
         end
       end
 
+      should "accept a connection to re-use" do
+        @client_mock.stubs(:body).returns( get_mock_body("events.json") )
+        reusable_connection = mock('Google::Connection')
+        reusable_connection.expects(:send).returns(@client_mock)
+
+        calendar = Calendar.new({:calendar => @calendar_id}, reusable_connection)
+        calendar.events
+      end
+
     end # login context
 
     context "and logged in" do
@@ -425,6 +434,14 @@ class TestGoogleCalendar < Minitest::Test
       assert_equal calendar.time_zone, "Europe/London"
       assert_equal calendar.access_role, "owner"
       assert_equal calendar.primary?, true
+    end
+
+    should "accept a connection to re-use" do
+      reusable_connection = mock('Google::Connection')
+      reusable_connection.expects(:send).returns(@client_mock)
+
+      calendar_list = CalendarList.new({}, reusable_connection)
+      calendar_list.fetch_entries
     end
 
   end

--- a/test/test_google_calendar.rb
+++ b/test/test_google_calendar.rb
@@ -421,19 +421,19 @@ class TestGoogleCalendar < Minitest::Test
     end
 
     should "find all calendars" do
-      calendars = @calendar_list.fetch_entries
-      assert_equal calendars.length, 3
-      assert_equal calendars.map(&:class).uniq, [CalendarListEntry]
-      assert_equal calendars.map(&:id), ["initech.com_ed493d0a9b46ea46c3a0d48611ce@resource.calendar.google.com", "initech.com_db18a4e59c230a5cc5d2b069a30f@resource.calendar.google.com", "bob@initech.com"]
+      entries = @calendar_list.fetch_entries
+      assert_equal entries.length, 3
+      assert_equal entries.map(&:class).uniq, [CalendarListEntry]
+      assert_equal entries.map(&:id), ["initech.com_ed493d0a9b46ea46c3a0d48611ce@resource.calendar.google.com", "initech.com_db18a4e59c230a5cc5d2b069a30f@resource.calendar.google.com", "bob@initech.com"]
     end
 
     should "set the calendar list entry parameters" do
-      calendar = @calendar_list.fetch_entries.find {|list_entry| list_entry.id == "bob@initech.com" }
+      entry = @calendar_list.fetch_entries.find {|list_entry| list_entry.id == "bob@initech.com" }
 
-      assert_equal calendar.summary, "Bob's Calendar"
-      assert_equal calendar.time_zone, "Europe/London"
-      assert_equal calendar.access_role, "owner"
-      assert_equal calendar.primary?, true
+      assert_equal entry.summary, "Bob's Calendar"
+      assert_equal entry.time_zone, "Europe/London"
+      assert_equal entry.access_role, "owner"
+      assert_equal entry.primary?, true
     end
 
     should "accept a connection to re-use" do
@@ -442,6 +442,15 @@ class TestGoogleCalendar < Minitest::Test
 
       calendar_list = CalendarList.new({}, reusable_connection)
       calendar_list.fetch_entries
+    end
+
+    should "return entries which can create calendars" do
+      entry = @calendar_list.fetch_entries.first
+      calendar = entry.to_calendar
+
+      assert_equal calendar.class, Calendar
+      assert_equal calendar.id, entry.id
+      assert_equal calendar.connection, @calendar_list.connection
     end
 
   end

--- a/test/test_google_calendar.rb
+++ b/test/test_google_calendar.rb
@@ -87,7 +87,7 @@ class TestGoogleCalendar < Minitest::Test
         start_min = now
         start_max = (now + 60*60*24)
         @calendar.expects(:event_lookup).with("?timeMin=#{start_min.strftime("%FT%TZ")}&timeMax=#{start_max.strftime("%FT%TZ")}&orderBy=startTime&maxResults=25&singleEvents=true")
-        events = @calendar.find_events_in_range(start_min, start_max)
+        @calendar.find_events_in_range(start_min, start_max)
       end
 
       should "find future events" do
@@ -95,7 +95,7 @@ class TestGoogleCalendar < Minitest::Test
         Time.stubs(:now).returns(now)
         formatted_time = now.strftime("%FT%TZ")
         @calendar.expects(:event_lookup).with("?timeMin=#{formatted_time}&orderBy=startTime&maxResults=25&singleEvents=true")
-        events = @calendar.find_future_events()
+        @calendar.find_future_events()
       end
 
       should "return multiple events in range as array" do

--- a/test/test_google_calendar.rb
+++ b/test/test_google_calendar.rb
@@ -103,13 +103,13 @@ class TestGoogleCalendar < Minitest::Test
         events = @calendar.events
         assert_equal events.class.to_s, "Array"
       end
-      
+
       should "return one event in range as array" do
         @client_mock.stubs(:body).returns( get_mock_body("query_events.json") )
         events = @calendar.events
         assert_equal events.class.to_s, "Array"
       end
-      
+
       should "return response of no events in range as array" do
         @client_mock.stubs(:body).returns( get_mock_body("empty_events.json") )
         events = @calendar.events
@@ -226,7 +226,7 @@ class TestGoogleCalendar < Minitest::Test
           @calendar.events
         end
       end
-      
+
       should "create event when id is NIL" do
         @client_mock.stubs(:body).returns( get_mock_body("find_event_by_id.json") )
 

--- a/test/test_google_calendar.rb
+++ b/test/test_google_calendar.rb
@@ -315,8 +315,19 @@ class TestGoogleCalendar < Minitest::Test
                             {'email' => 'some.b.one@gmail.com', 'displayName' => 'Some B One', 'responseStatus' => 'tentative'}
                           ]
 
-        correct_json = "{ \"summary\": \"Go Swimming\", \"description\": \"The polar bear plunge\", \"location\": \"In the arctic ocean\", \"start\": { \"dateTime\": \"#{@event.start_time}\" }, \"end\": { \"dateTime\": \"#{@event.end_time}\" }, \"attendees\": [{ \"displayName\": \"Some A One\", \"email\": \"some.a.one@gmail.com\", \"responseStatus\": \"tentative\" },{ \"displayName\": \"Some B One\", \"email\": \"some.b.one@gmail.com\", \"responseStatus\": \"tentative\" }], \"reminders\": { \"useDefault\": false,\"overrides\": [{ \"method\": \"popup\", \"minutes\": 10 }] } }"
-        assert_equal @event.to_json.gsub("\n", "").gsub(/\s+/, ' '), correct_json
+        expected_structure = {
+          "summary" => "Go Swimming",
+          "description" => "The polar bear plunge",
+          "location" => "In the arctic ocean",
+          "start" => {"dateTime" => "#{@event.start_time}"},
+          "end" => {"dateTime" => "#{@event.end_time}"},
+          "attendees" => [
+            {"displayName" => "Some A One", "email" => "some.a.one@gmail.com", "responseStatus" => "tentative"},
+            {"displayName" => "Some B One", "email" => "some.b.one@gmail.com", "responseStatus" => "tentative"}
+          ],
+          "reminders" => {"useDefault" => false, "overrides" => [{"method" => "popup", "minutes" => 10}]}
+        }
+        assert_equal JSON.parse(@event.to_json), expected_structure
       end
     end
 
@@ -356,8 +367,20 @@ class TestGoogleCalendar < Minitest::Test
                             {'email' => 'some.b.one@gmail.com', 'displayName' => 'Some B One', 'responseStatus' => 'tentative'}
                           ]
         @event.recurrence = {freq: "monthly", count: "5", interval: "2"}
-        correct_json = "{ \"summary\": \"Go Swimming\", \"description\": \"The polar bear plunge\", \"location\": \"In the arctic ocean\", \"start\": { \"dateTime\": \"#{@event.start_time}\" ,\"timeZone\" : \"#{Time.now.getlocal.zone}\" }, \"end\": { \"dateTime\": \"#{@event.end_time}\" ,\"timeZone\" : \"#{Time.now.getlocal.zone}\" }, \"recurrence\": [\"RRULE:FREQ=MONTHLY;COUNT=5;INTERVAL=2\"], \"attendees\": [{ \"displayName\": \"Some A One\", \"email\": \"some.a.one@gmail.com\", \"responseStatus\": \"tentative\" },{ \"displayName\": \"Some B One\", \"email\": \"some.b.one@gmail.com\", \"responseStatus\": \"tentative\" }], \"reminders\": { \"useDefault\": false,\"overrides\": [{ \"method\": \"popup\", \"minutes\": 10 }] } }"
-        assert_equal @event.to_json.gsub("\n", "").gsub(/\s+/, ' '), correct_json
+        expected_structure = {
+          "summary" => "Go Swimming",
+          "description" => "The polar bear plunge",
+          "location" => "In the arctic ocean",
+          "start" => {"dateTime" => "#{@event.start_time}", "timeZone" => "#{Time.now.getlocal.zone}"},
+          "end" => {"dateTime" => "#{@event.end_time}", "timeZone" => "#{Time.now.getlocal.zone}"},
+          "recurrence" => ["RRULE:FREQ=MONTHLY;COUNT=5;INTERVAL=2"],
+          "attendees" => [
+            {"displayName" => "Some A One", "email" => "some.a.one@gmail.com", "responseStatus" => "tentative"},
+            {"displayName" => "Some B One", "email" => "some.b.one@gmail.com", "responseStatus" => "tentative"}
+          ],
+          "reminders" => {"useDefault" => false, "overrides" => [{"method" => "popup", "minutes"=>10}]}
+        }
+        assert_equal JSON.parse(@event.to_json), expected_structure
       end
 
       should "parse recurrence rule strings corectly" do


### PR DESCRIPTION
Hi,

We've added support for retrieving the user's [Calendar List](https://developers.google.com/google-apps/calendar/v3/reference/#CalendarList) from the Google API.

Thanks,
Tom @tomwhoiscontrary and Oli @odlp