### PR TITLE
Applied 'Patch for "find_or_create_by_id" from master.

### DIFF
--- a/lib/google/calendar.rb
+++ b/lib/google/calendar.rb
@@ -187,7 +187,11 @@ module Google
     # Works like the create_event method.
     #
     def find_or_create_event_by_id(id, &blk)
-      setup_event(find_event_by_id(id)[0] || Event.new, &blk)
+      if id.nil?
+        setup_event(Event.new, &blk)
+      else
+        setup_event(find_event_by_id(id)[0] || Event.new, &blk)
+      end
     end
 
     #

--- a/test/test_google_calendar.rb
+++ b/test/test_google_calendar.rb
@@ -205,6 +205,16 @@ class TestGoogleCalendar < Minitest::Test
         end
       end
 
+      should "create event when id is NIL" do
+        @client_mock.stubs(:body).returns( get_mock_body("find_event_by_id.json") )
+
+        event = @calendar.find_or_create_event_by_id(NIL) do |e|
+          e.title = 'New Event Update when id is NIL'
+        end
+
+        assert_equal event.title, 'New Event Update when id is NIL'
+      end
+      
     end # Logged on context
 
   end # Connected context


### PR DESCRIPTION
Applied same fix from mater branch to ruby-1.8.7 to allow find_or_create_event_by_id to work when passed a nil value.