### PR TITLE
Fix find_or_create_event_by_id if there is not matching non-NIL event id

### DIFF
--- a/lib/google/calendar.rb
+++ b/lib/google/calendar.rb
@@ -190,7 +190,8 @@ module Google
       if id.nil?
         setup_event(Event.new, &blk)
       else
-        setup_event(find_event_by_id(id)[0] || Event.new, &blk)
+        event = find_event_by_id(id)
+        setup_event(event ? event[0] : Event.new, &blk)
       end
     end
 

--- a/test/test_google_calendar.rb
+++ b/test/test_google_calendar.rb
@@ -215,6 +215,17 @@ class TestGoogleCalendar < Minitest::Test
         assert_equal event.title, 'New Event Update when id is NIL'
       end
       
+      should "find or create will create event when id is not found" do
+        @client_mock.stubs(:status).returns(404)
+        @client_mock.stubs(:body).returns( get_mock_body("404.json") )
+        event = @calendar.find_or_create_event_by_id('does_not_exist') do |e|
+          @client_mock.stubs(:body).returns( get_mock_body("create_event.json") )
+          @client_mock.stubs(:status).returns(200)
+          e.title = 'New Event Update when id is NIL'
+        end
+
+        assert_equal event.title, 'New Event Update when id is NIL'
+      end
     end # Logged on context
 
   end # Connected context


### PR DESCRIPTION
Code was attempting to treat a nil as an array.  Now will properly create a new event if the event with a matching id is not found.