### PR TITLE
Added 'id' as a writable attributes as specified in Google V3 API, with format validation

### DIFF
--- a/lib/google/calendar.rb
+++ b/lib/google/calendar.rb
@@ -155,7 +155,7 @@ module Google
     #   an array of events if many found.
     #
     def find_event_by_id(id)
-      return nil unless id && id.strip != ''
+      return nil unless id 
       event_lookup("/#{id}")
     end
 
@@ -187,11 +187,7 @@ module Google
     # Works like the create_event method.
     #
     def find_or_create_event_by_id(id, &blk)
-      if id.nil?
-        setup_event(Event.new, &blk)
-      else
-        setup_event(find_event_by_id(id)[0] || Event.new, &blk)
-      end
+      setup_event(find_event_by_id(id)[0] || Event.new, &blk)
     end
 
     #

--- a/lib/google/calendar.rb
+++ b/lib/google/calendar.rb
@@ -187,7 +187,12 @@ module Google
     # Works like the create_event method.
     #
     def find_or_create_event_by_id(id, &blk)
-      setup_event(find_event_by_id(id)[0] || Event.new, &blk)
+      if id.nil?
+        setup_event(Event.new, &blk)
+      else
+        setup_event(find_event_by_id(id)[0] || Event.new, &blk)
+      end
+      # setup_event(find_event_by_id(id)[0] || Event.new, &blk)
     end
 
     #

--- a/lib/google/calendar.rb
+++ b/lib/google/calendar.rb
@@ -192,7 +192,6 @@ module Google
       else
         setup_event(find_event_by_id(id)[0] || Event.new, &blk)
       end
-      # setup_event(find_event_by_id(id)[0] || Event.new, &blk)
     end
 
     #

--- a/lib/google/event.rb
+++ b/lib/google/event.rb
@@ -64,7 +64,7 @@ module Google
     # Sets the id of the Event.
     #
     def id=(id)
-      @id = Event.parse_id(id)
+      @id = Event.parse_id(id) unless id.nil?
     end
 
     #
@@ -218,7 +218,6 @@ module Google
     #
     def to_json
       "{
-        \"id\": \"#{id}\",
         \"summary\": \"#{title}\",
         \"description\": \"#{description}\",
         \"location\": \"#{location}\",
@@ -408,7 +407,7 @@ module Google
     # Validates id format
     #
     def self.parse_id(id)
-      raise ArgumentError, "Event ID is invalid. Please check Google documentation: https://developers.google.com/google-apps/calendar/v3/reference/events/insert" if id.gsub(/(^[a-v0-9]{5,1024}$)/o)      
+      raise ArgumentError, "Event ID is invalid. Please check Google documentation: https://developers.google.com/google-apps/calendar/v3/reference/events/insert" unless id.gsub(/(^[a-v0-9]{5,1024}$)/o)      
     end
 
   end

--- a/lib/google/event.rb
+++ b/lib/google/event.rb
@@ -8,7 +8,7 @@ module Google
   #
   # === Attributes
   #
-  # * +id+ - The google assigned id of the event (nil until saved). Read only.
+  # * +id+ - The google assigned id of the event (nil until saved). Read Write.
   # * +status+ - The status of the event (confirmed, tentative or cancelled). Read only.
   # * +title+ - The title of the event. Read Write.
   # * +description+ - The content of the event. Read Write.
@@ -27,8 +27,8 @@ module Google
   # * +raw+ - The full google json representation of the event. Read only.
   #
   class Event
-    attr_reader :id, :raw, :html_link, :status
-    attr_accessor :title, :location, :calendar, :quickadd, :transparency, :attendees, :description, :reminders, :recurrence
+    attr_reader :raw, :html_link, :status
+    attr_accessor :id, :title, :location, :calendar, :quickadd, :transparency, :attendees, :description, :reminders, :recurrence
 
     #
     # Create a new event, and optionally set it's attributes.
@@ -37,6 +37,7 @@ module Google
     #
     # event = Google::Event.new
     # event.calendar = AnInstanceOfGoogleCalendaer
+    # event.id = "0123456789abcdefghijklmopqrstuv"
     # event.start_time = Time.now
     # event.end_time = Time.now + (60 * 60)
     # event.recurrence = {'freq' => 'monthly'}
@@ -57,6 +58,13 @@ module Google
 
       self.transparency = params[:transparency]
       self.all_day      = params[:all_day] if params[:all_day]
+    end
+
+    #
+    # Sets the id of the Event.
+    #
+    def id=(id)
+      @id = Event.parse_id(id)
     end
 
     #
@@ -210,6 +218,7 @@ module Google
     #
     def to_json
       "{
+        \"id\": \"#{id}\",
         \"summary\": \"#{title}\",
         \"description\": \"#{description}\",
         \"location\": \"#{location}\",
@@ -393,6 +402,13 @@ module Google
     def self.parse_time(time) #:nodoc
       raise ArgumentError, "Start Time must be either Time or String" unless (time.is_a?(String) || time.is_a?(Time))
       (time.is_a? String) ? Time.parse(time) : time.dup.utc
+    end
+
+    #
+    # Validates id format
+    #
+    def self.parse_id(id)
+      raise ArgumentError, "Event ID is invalid. Please check Google documentation: https://developers.google.com/google-apps/calendar/v3/reference/events/insert" if id.gsub(/(^[a-v0-9]{5,1024}$)/o)      
     end
 
   end

--- a/test/test_google_calendar.rb
+++ b/test/test_google_calendar.rb
@@ -319,6 +319,7 @@ class TestGoogleCalendar < Minitest::Test
 
         expected_structure = {
           "summary" => "Go Swimming",
+          "visibility"=>"default",
           "description" => "The polar bear plunge",
           "location" => "In the arctic ocean",
           "start" => {"dateTime" => "#{@event.start_time}"},
@@ -370,7 +371,8 @@ class TestGoogleCalendar < Minitest::Test
                           ]
         @event.recurrence = {freq: "monthly", count: "5", interval: "2"}
         expected_structure = {
-          "summary" => "Go Swimming",
+          "summary" => "Go Swimming", 
+          "visibility"=>"default",
           "description" => "The polar bear plunge",
           "location" => "In the arctic ocean",
           "start" => {"dateTime" => "#{@event.start_time}", "timeZone" => "#{Time.now.getlocal.zone}"},


### PR DESCRIPTION
Now ID can be specified when you create an event as talked here https://github.com/northworld/google_calendar/issues/61 
I currently don't have a ruby environment to launch the tests, let's see what travis says.