### PR TITLE
added TimezoneParser to list of gems, to obtain the extended timezone…

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,12 +2,16 @@ PATH
   remote: .
   specs:
     google_calendar (0.5)
+      TimezoneParser (~> 0.2.0)
       json (~> 1.8)
       signet (~> 0.6)
 
 GEM
   remote: http://rubygems.org/
   specs:
+    TimezoneParser (0.2.0)
+      insensitive_hash
+      tzinfo
     addressable (2.3.8)
     ansi (1.5.0)
     builder (3.2.2)
@@ -17,8 +21,9 @@ GEM
     extlib (0.9.16)
     faraday (0.9.1)
       multipart-post (>= 1.2, < 3)
+    insensitive_hash (0.3.3)
     json (1.8.2)
-    jwt (1.5.0)
+    jwt (1.5.1)
     metaclass (0.0.4)
     minitest (5.6.1)
     minitest-reporters (1.0.16)
@@ -28,7 +33,7 @@ GEM
       ruby-progressbar
     mocha (1.1.0)
       metaclass (~> 0.0.1)
-    multi_json (1.11.0)
+    multi_json (1.11.2)
     multipart-post (2.0.0)
     rake (10.4.2)
     rb-fsevent (0.9.5)
@@ -36,11 +41,11 @@ GEM
       json (~> 1.4)
     ruby-progressbar (1.7.5)
     shoulda-context (1.2.1)
-    signet (0.6.0)
+    signet (0.6.1)
       addressable (~> 2.3)
       extlib (~> 0.9)
       faraday (~> 0.9)
-      jwt (~> 1.0)
+      jwt (~> 1.5)
       multi_json (~> 1.10)
     simplecov (0.10.0)
       docile (~> 1.1.0)
@@ -48,6 +53,9 @@ GEM
       simplecov-html (~> 0.10.0)
     simplecov-html (0.10.0)
     terminal-notifier-guard (1.6.4)
+    thread_safe (0.3.5)
+    tzinfo (1.2.2)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby
@@ -64,3 +72,6 @@ DEPENDENCIES
   rdoc (~> 4.1)
   shoulda-context (~> 1.2)
   terminal-notifier-guard (~> 1.6)
+
+BUNDLED WITH
+   1.10.5

--- a/google_calendar.gemspec
+++ b/google_calendar.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
 
   s.add_runtime_dependency(%q<signet>, ["~> 0.6"])
   s.add_runtime_dependency(%q<json>, ["~> 1.8"])
+  s.add_runtime_dependency(%q<TimezoneParser>, ["~> 0.2.0"])
 
   s.add_development_dependency(%q<terminal-notifier-guard>, ["~> 1.6"])
   s.add_development_dependency(%q<rb-fsevent>, ["~> 0.9"])

--- a/lib/google/event.rb
+++ b/lib/google/event.rb
@@ -1,5 +1,6 @@
 require 'time'
 require 'json'
+require 'timezone_parser'
 
 module Google
 
@@ -303,7 +304,9 @@ module Google
     # JSON representation of local timezone
     #
     def local_timezone_json
-      ",\"timeZone\" : \"#{Time.now.getlocal.zone}\""
+      tz = Time.now.getlocal.zone
+      tz_name = TimezoneParser::getTimezones(tz).last
+      ",\"timeZone\" : \"#{tz_name}\""
     end
 
     #

--- a/test/test_google_calendar.rb
+++ b/test/test_google_calendar.rb
@@ -389,13 +389,14 @@ class TestGoogleCalendar < Minitest::Test
                             {'email' => 'some.b.one@gmail.com', 'displayName' => 'Some B One', 'responseStatus' => 'tentative'}
                           ]
         @event.recurrence = {freq: "monthly", count: "5", interval: "2"}
+        require 'timezone_parser'
         expected_structure = {
           "summary" => "Go Swimming",
           "visibility"=>"default",
           "description" => "The polar bear plunge",
           "location" => "In the arctic ocean",
-          "start" => {"dateTime" => "#{@event.start_time}", "timeZone" => "#{Time.now.getlocal.zone}"},
-          "end" => {"dateTime" => "#{@event.end_time}", "timeZone" => "#{Time.now.getlocal.zone}"},
+          "start" => {"dateTime" => "#{@event.start_time}", "timeZone" => "#{TimezoneParser::getTimezones(Time.now.getlocal.zone).last}"},
+          "end" => {"dateTime" => "#{@event.end_time}", "timeZone" => "#{TimezoneParser::getTimezones(Time.now.getlocal.zone).last}"},
           "recurrence" => ["RRULE:FREQ=MONTHLY;COUNT=5;INTERVAL=2"],
           "attendees" => [
             {"displayName" => "Some A One", "email" => "some.a.one@gmail.com", "responseStatus" => "tentative"},


### PR DESCRIPTION
I was using your gem for a pet project (https://github.com/tganzarolli/offlook) and stumbled upon a little bug. I monkey patched it in my code but also fixed it here.
When you create a recurring event, timezone is needed. The information you supplied is the abbreviated timezone, however the Google Calendar API requires the extended version. As follows: 
https://developers.google.com/google-apps/calendar/recurringevents
![screenshot 2015-07-05 16 14 03](https://cloud.githubusercontent.com/assets/29720/8512999/e99cb5c0-2330-11e5-9646-9e19d161f5d1.png)
To get that information I had to use another gem called TimezoneParser. I didn't find a better way to do this. Hence the new dependency.

Cheers,
Thiago
