### PR TITLE
No Event Found Fix

### DIFF
--- a/lib/google/calendar.rb
+++ b/lib/google/calendar.rb
@@ -301,7 +301,7 @@ module Google
         return events if events.empty?
         events.length > 1 ? events : [events[0]]
       rescue Google::HTTPNotFound
-        return nil
+        return []
       end
     end
 

--- a/test/test_google_calendar.rb
+++ b/test/test_google_calendar.rb
@@ -134,7 +134,7 @@ class TestGoogleCalendar < Minitest::Test
       should "throw NotFound with invalid event id" do
         @client_mock.stubs(:status).returns(404)
         @client_mock.stubs(:body).returns( get_mock_body("404.json") )
-        assert_equal @calendar.find_event_by_id('1234'), nil
+        assert_equal @calendar.find_event_by_id('1234'), []
       end
 
       should "create an event with block" do


### PR DESCRIPTION
Methods that use the `event_lookup` method are expecting a blank array to be returned if no events are found. However, it was returning nil. This caused this error:

~~~
undefined method `[]' for nil:NilClass (NoMethodError)
~~~

This fixes the problem for me.