### PR TITLE
Added support for event custom attributes (aka extended properties)

### DIFF
--- a/lib/google/connection.rb
+++ b/lib/google/connection.rb
@@ -111,7 +111,6 @@ module Google
     def send(path, method, content = '')
 
       uri = BASE_URI + path
-
       response = @client.fetch_protected_resource(
         :uri => uri,
         :method => method,

--- a/readme_code.rb
+++ b/readme_code.rb
@@ -47,6 +47,14 @@ event = cal.create_event do |e|
   e.title = 'A Cool Event'
   e.start_time = Time.now
   e.end_time = Time.now + (60 * 60) # seconds * min
+  e.extended_properties = {
+    'private' => {
+      'private_prop' => 'private_val'
+    },
+    'shared' => {
+      'shared_prop' => 'shared_val'
+    }
+  }
 end
 
 puts event
@@ -59,8 +67,13 @@ end
 
 puts event
 
+# Find through the custom property
+event = cal.find_events_by_extended_properties({'private' => { 'private_prop' => 'private_val'}})
+
+puts event
+
 # All events
 puts cal.events
 
 # Query events
-puts cal.find_events('your search string')
+puts cal.find_events('some query here')

--- a/test/mocks/create_event.json
+++ b/test/mocks/create_event.json
@@ -1,31 +1,36 @@
 {
-  "status": "confirmed", 
-  "kind": "calendar#event", 
+  "status": "confirmed",
+  "kind": "calendar#event",
   "end": {
     "dateTime": "2014-11-16T21:17:31-08:00"
-  }, 
-  "description": "A New Event", 
-  "created": "2014-11-17T03:19:37.000Z", 
-  "iCalUID": "fhru34kt6ikmr20knd2456l08n@google.com", 
+  },
+  "description": "A New Event",
+  "created": "2014-11-17T03:19:37.000Z",
+  "iCalUID": "fhru34kt6ikmr20knd2456l08n@google.com",
   "reminders": {
     "useDefault": true
-  }, 
-  "htmlLink": "https://www.google.com/calendar/event?eid=aslkjhdfasod89f7aspdfghsdlkfghsdlkjghsdfgposdr7gpsdorigh", 
-  "sequence": 0, 
-  "updated": "2014-11-17T03:19:37.944Z", 
-  "summary": "New Event", 
+  },
+  "htmlLink": "https://www.google.com/calendar/event?eid=aslkjhdfasod89f7aspdfghsdlkfghsdlkjghsdfgposdr7gpsdorigh",
+  "sequence": 0,
+  "updated": "2014-11-17T03:19:37.944Z",
+  "summary": "New Event",
   "start": {
     "dateTime": "2014-11-16T20:17:31-08:00"
-  }, 
-  "etag": "\"123456728900000\"", 
+  },
+  "etag": "\"123456728900000\"",
   "organizer": {
-    "self": true, 
-    "displayName": "Some Person", 
+    "self": true,
+    "displayName": "Some Person",
     "email": "klei8jnelo09nflqehnvfzipgs@group.calendar.google.com"
-  }, 
+  },
   "creator": {
-    "displayName": "Some Person", 
+    "displayName": "Some Person",
     "email": "some.person@gmail.com"
-  }, 
-  "id": "fhru34kt6ikmr20knd2456l08n"
+  },
+  "id": "fhru34kt6ikmr20knd2456l08n",
+  "extendedProperties": {
+    "shared": {
+      "key": "value"
+    }
+  }
 }

--- a/test/mocks/events.json
+++ b/test/mocks/events.json
@@ -1,117 +1,132 @@
 {
-  "nextPageToken": "CkkKO183NTM0Mmdobzc0cDNhYmE0ODUyajZiOWs2bDBqMmJhMTZsMjNjYmExOHAyajhoOXA3NG80YWRoaDZrGAEggICA7NHLrqgTGg0IABIAGIjyiZnV_cEC", 
-  "kind": "calendar#events", 
-  "defaultReminders": [], 
-  "description": "My Personal Events Calenda", 
+  "nextPageToken": "CkkKO183NTM0Mmdobzc0cDNhYmE0ODUyajZiOWs2bDBqMmJhMTZsMjNjYmExOHAyajhoOXA3NG80YWRoaDZrGAEggICA7NHLrqgTGg0IABIAGIjyiZnV_cEC",
+  "kind": "calendar#events",
+  "defaultReminders": [],
+  "description": "My Personal Events Calenda",
   "items": [
     {
-      "status": "confirmed", 
-      "kind": "calendar#event", 
+      "status": "confirmed",
+      "kind": "calendar#event",
       "end": {
-        "timeZone": "America/Los_Angeles", 
+        "timeZone": "America/Los_Angeles",
         "dateTime": "2011-10-03T10:30:00-07:00"
-      }, 
-      "created": "2011-04-04T23:52:57.000Z", 
-      "iCalUID": "fhru34kt6ikmr20knd2456l08n@google.com", 
+      },
+      "created": "2011-04-04T23:52:57.000Z",
+      "iCalUID": "fhru34kt6ikmr20knd2456l08n@google.com",
       "reminders": {
         "useDefault": true
-      }, 
-      "htmlLink": "https://www.google.com/calendar/event?eid=HikHg9bQzIk2dWtpdTRwM3Zpazd0cHMwcjRfMjAxMTEwMDNUMTYzMDAwWiBncWViMGk2djczN2tmdTVtZDBmM2V1a2psZ0Bn", 
-      "sequence": 2, 
-      "updated": "2012-01-09T19:39:49.000Z", 
-      "summary": "Staff Meeting", 
+      },
+      "htmlLink": "https://www.google.com/calendar/event?eid=HikHg9bQzIk2dWtpdTRwM3Zpazd0cHMwcjRfMjAxMTEwMDNUMTYzMDAwWiBncWViMGk2djczN2tmdTVtZDBmM2V1a2psZ0Bn",
+      "sequence": 2,
+      "updated": "2012-01-09T19:39:49.000Z",
+      "summary": "Staff Meeting",
       "recurrence": [
         "RRULE:FREQ=WEEKLY;WKST=SU;UNTIL=20120109T075959Z;BYDAY=MO"
-      ], 
+      ],
       "start": {
-        "timeZone": "America/Los_Angeles", 
+        "timeZone": "America/Los_Angeles",
         "dateTime": "2011-10-03T09:30:00-07:00"
-      }, 
-      "etag": "\"2652275978000000\"", 
+      },
+      "etag": "\"2652275978000000\"",
       "organizer": {
-        "self": true, 
-        "displayName": "Some Person", 
+        "self": true,
+        "displayName": "Some Person",
         "email": "klei8jnelo09nflqehnvfzipgs@group.calendar.google.com"
-      }, 
+      },
       "creator": {
-        "displayName": "Some Person", 
+        "displayName": "Some Person",
         "email": "some.person@gmail.com"
-      }, 
-      "id": "fhru34kt6ikmr20knd2456l08n"
-    }, 
+      },
+      "id": "fhru34kt6ikmr20knd2456l08n",
+      "extendedProperties": {
+        "shared": {
+          "key": "value"
+        }
+      }
+    },
     {
-      "status": "confirmed", 
-      "kind": "calendar#event", 
+      "status": "confirmed",
+      "kind": "calendar#event",
       "end": {
-        "timeZone": "America/Los_Angeles", 
+        "timeZone": "America/Los_Angeles",
         "dateTime": "2011-10-03T11:00:00-07:00"
-      }, 
-      "created": "2010-06-01T03:53:00.000Z", 
-      "iCalUID": "fhru34kt6ikmr20knd2456l08n@google.com", 
+      },
+      "created": "2010-06-01T03:53:00.000Z",
+      "iCalUID": "fhru34kt6ikmr20knd2456l08n@google.com",
       "reminders": {
         "useDefault": true
-      }, 
-      "htmlLink": "https://www.google.com/calendar/event?eidi1wegp0jHmAFucjlhMXY0c2RqMjBpYXNlNmNfMjAxMTEwMDNUMTczMDAwWiBncWViMGk2djczN2tmdTVtZDBmM2V1a2psZ0Bn", 
-      "sequence": 2, 
-      "updated": "2012-01-13T18:24:01.000Z", 
-      "summary": "Skype Meeting", 
+      },
+      "htmlLink": "https://www.google.com/calendar/event?eidi1wegp0jHmAFucjlhMXY0c2RqMjBpYXNlNmNfMjAxMTEwMDNUMTczMDAwWiBncWViMGk2djczN2tmdTVtZDBmM2V1a2psZ0Bn",
+      "sequence": 2,
+      "updated": "2012-01-13T18:24:01.000Z",
+      "summary": "Skype Meeting",
       "recurrence": [
         "RRULE:FREQ=WEEKLY;UNTIL=20120109T183000Z"
-      ], 
+      ],
       "start": {
-        "timeZone": "America/Los_Angeles", 
+        "timeZone": "America/Los_Angeles",
         "dateTime": "2011-10-03T10:30:00-07:00"
-      }, 
-      "etag": "\"2652958082000000\"", 
+      },
+      "etag": "\"2652958082000000\"",
       "organizer": {
-        "self": true, 
-        "displayName": "Some Person", 
+        "self": true,
+        "displayName": "Some Person",
         "email": "some.person@gmail.com"
-      }, 
+      },
       "creator": {
-        "displayName": "Some Person", 
+        "displayName": "Some Person",
         "email": "some.person@gmail.com"
-      }, 
-      "id": "fhru34kt6ikmr20knd2456l08n"
-    }, 
+      },
+      "id": "fhru34kt6ikmr20knd2456l08n",
+      "extendedProperties": {
+        "shared": {
+          "key": "value"
+        }
+      }
+    },
     {
-      "status": "confirmed", 
-      "kind": "calendar#event", 
+      "status": "confirmed",
+      "kind": "calendar#event",
       "end": {
-        "timeZone": "America/Los_Angeles", 
+        "timeZone": "America/Los_Angeles",
         "dateTime": "2012-01-09T10:15:00-08:00"
-      }, 
-      "created": "2012-01-09T19:39:50.000Z", 
+      },
+      "created": "2012-01-09T19:39:50.000Z",
       "reminders": {
         "useDefault": true
-      }, 
-      "htmlLink": "https://www.google.com/calendar/event?eid=uIf5JKmaPdhvNzRwM2FiYTQ4NTJqNmI5azZsMGoyYmExNmwyM2NiYTE4cDJqOGg5cDc0bzRhZGhoNmtfMjAxMjAxMDlUMTcxNTAwWiBncWViMGk2djczN2tmdTVtZDBmM2V1a2psZ0Bn", 
-      "sequence": 3, 
-      "updated": "2012-01-23T17:38:31.000Z", 
-      "summary": "Sales Staff Meeting", 
+      },
+      "htmlLink": "https://www.google.com/calendar/event?eid=uIf5JKmaPdhvNzRwM2FiYTQ4NTJqNmI5azZsMGoyYmExNmwyM2NiYTE4cDJqOGg5cDc0bzRhZGhoNmtfMjAxMjAxMDlUMTcxNTAwWiBncWViMGk2djczN2tmdTVtZDBmM2V1a2psZ0Bn",
+      "sequence": 3,
+      "updated": "2012-01-23T17:38:31.000Z",
+      "summary": "Sales Staff Meeting",
       "recurrence": [
         "RRULE:FREQ=WEEKLY;WKST=SU;UNTIL=20120123T171459Z;BYDAY=MO"
-      ], 
+      ],
       "start": {
-        "timeZone": "America/Los_Angeles", 
+        "timeZone": "America/Los_Angeles",
         "dateTime": "2012-01-09T09:15:00-08:00"
-      }, 
-      "etag": "\"2654680622000000\"", 
+      },
+      "etag": "\"2654680622000000\"",
       "organizer": {
-        "self": true, 
-        "displayName": "Some Person", 
+        "self": true,
+        "displayName": "Some Person",
         "email": "some.person@gmail.com"
-      }, 
+      },
       "creator": {
-        "displayName": "Some Person", 
+        "displayName": "Some Person",
         "email": "some.person@gmail.com"
-      }, 
-      "id": "_75342gho74p3aba4852j6b9k6l0j2ba16l23cba18p2j8h9p74o4adhh6k"
+      },
+      "id": "_75342gho74p3aba4852j6b9k6l0j2ba16l23cba18p2j8h9p74o4adhh6k",
+      "extendedProperties": {
+        "shared": {
+          "key": "value"
+        }
+      }
     }
-  ], 
-  "updated": "2014-11-15T22:32:46.965Z", 
-  "summary": "My Events Calendar", 
-  "etag": "\"1234567890123000\"", 
-  "timeZone": "America/Los_Angeles", 
+  ],
+  "updated": "2014-11-15T22:32:46.965Z",
+  "summary": "My Events Calendar",
+  "etag": "\"1234567890123000\"",
+  "timeZone": "America/Los_Angeles",
   "accessRole": "owner"
 }

--- a/test/mocks/find__all_day_event_by_id.json
+++ b/test/mocks/find__all_day_event_by_id.json
@@ -1,31 +1,36 @@
 {
-  "status": "confirmed", 
-  "kind": "calendar#event", 
+  "status": "confirmed",
+  "kind": "calendar#event",
   "end": {
     "date": "2008-09-24T11:00:00-07:00"
-  }, 
-  "description": "Test Event", 
-  "created": "2008-09-18T21:17:11.000Z", 
-  "iCalUID": "fhru34kt6ikmr20knd2456l08n@google.com", 
+  },
+  "description": "Test Event",
+  "created": "2008-09-18T21:17:11.000Z",
+  "iCalUID": "fhru34kt6ikmr20knd2456l08n@google.com",
   "reminders": {
     "useDefault": true
-  }, 
-  "htmlLink": "https://www.google.com/calendar/event?eid=hJo0SgXn9qMwOHJjYWJpNnBhNTQ5dHRqbGsgZ3FlYjBpNnY3MzdrZnU1bWQwZjNldWtqbGdAZw", 
-  "sequence": 1, 
-  "updated": "2008-10-24T23:08:09.010Z", 
-  "summary": "This is a test event", 
+  },
+  "htmlLink": "https://www.google.com/calendar/event?eid=hJo0SgXn9qMwOHJjYWJpNnBhNTQ5dHRqbGsgZ3FlYjBpNnY3MzdrZnU1bWQwZjNldWtqbGdAZw",
+  "sequence": 1,
+  "updated": "2008-10-24T23:08:09.010Z",
+  "summary": "This is a test event",
   "start": {
     "date": "2008-09-24T10:30:00-07:00"
-  }, 
-  "etag": "\"2449779378020000\"", 
+  },
+  "etag": "\"2449779378020000\"",
   "organizer": {
-    "self": true, 
-    "displayName": "Some Person", 
+    "self": true,
+    "displayName": "Some Person",
     "email": "some.person@gmail.com"
-  }, 
+  },
   "creator": {
-    "displayName": "Some Person", 
+    "displayName": "Some Person",
     "email": "some.person@gmail.com"
-  }, 
-  "id": "fhru34kt6ikmr20knd2456l10n"
+  },
+  "id": "fhru34kt6ikmr20knd2456l10n",
+  "extendedProperties": {
+    "shared": {
+      "key": "value"
+    }
+  }
 }

--- a/test/mocks/find_event_by_id.json
+++ b/test/mocks/find_event_by_id.json
@@ -1,31 +1,36 @@
 {
-  "status": "confirmed", 
-  "kind": "calendar#event", 
+  "status": "confirmed",
+  "kind": "calendar#event",
   "end": {
     "dateTime": "2008-09-24T11:00:00-07:00"
-  }, 
-  "description": "Test Event", 
-  "created": "2008-09-18T21:17:11.000Z", 
-  "iCalUID": "fhru34kt6ikmr20knd2456l08n@google.com", 
+  },
+  "description": "Test Event",
+  "created": "2008-09-18T21:17:11.000Z",
+  "iCalUID": "fhru34kt6ikmr20knd2456l08n@google.com",
   "reminders": {
     "useDefault": true
-  }, 
-  "htmlLink": "https://www.google.com/calendar/event?eid=hJo0SgXn9qMwOHJjYWJpNnBhNTQ5dHRqbGsgZ3FlYjBpNnY3MzdrZnU1bWQwZjNldWtqbGdAZw", 
-  "sequence": 1, 
-  "updated": "2008-10-24T23:08:09.010Z", 
-  "summary": "This is a test event", 
+  },
+  "htmlLink": "https://www.google.com/calendar/event?eid=hJo0SgXn9qMwOHJjYWJpNnBhNTQ5dHRqbGsgZ3FlYjBpNnY3MzdrZnU1bWQwZjNldWtqbGdAZw",
+  "sequence": 1,
+  "updated": "2008-10-24T23:08:09.010Z",
+  "summary": "This is a test event",
   "start": {
     "dateTime": "2008-09-24T10:30:00-07:00"
-  }, 
-  "etag": "\"2449779378020000\"", 
+  },
+  "etag": "\"2449779378020000\"",
   "organizer": {
-    "self": true, 
-    "displayName": "Some Person", 
+    "self": true,
+    "displayName": "Some Person",
     "email": "some.person@gmail.com"
-  }, 
+  },
   "creator": {
-    "displayName": "Some Person", 
+    "displayName": "Some Person",
     "email": "some.person@gmail.com"
-  }, 
-  "id": "fhru34kt6ikmr20knd2456l08n"
+  },
+  "id": "fhru34kt6ikmr20knd2456l08n",
+  "extendedProperties": {
+    "shared": {
+      "key": "value"
+    }
+  }
 }

--- a/test/mocks/missing_date.json
+++ b/test/mocks/missing_date.json
@@ -1,31 +1,36 @@
 {
-  "status": "confirmed", 
-  "kind": "calendar#event", 
+  "status": "confirmed",
+  "kind": "calendar#event",
   "end": {
     "dateTimes": "2008-09-24T11:00:00-07:00"
-  }, 
-  "description": "Test Event", 
-  "created": "2008-09-18T21:17:11.000Z", 
-  "iCalUID": "fhru34kt6ikmr20knd2456l08n@google.com", 
+  },
+  "description": "Test Event",
+  "created": "2008-09-18T21:17:11.000Z",
+  "iCalUID": "fhru34kt6ikmr20knd2456l08n@google.com",
   "reminders": {
     "useDefault": true
-  }, 
-  "htmlLink": "https://www.google.com/calendar/event?eid=hJo0SgXn9qMwOHJjYWJpNnBhNTQ5dHRqbGsgZ3FlYjBpNnY3MzdrZnU1bWQwZjNldWtqbGdAZw", 
-  "sequence": 1, 
-  "updated": "2008-10-24T23:08:09.010Z", 
-  "summary": "This is a test event", 
+  },
+  "htmlLink": "https://www.google.com/calendar/event?eid=hJo0SgXn9qMwOHJjYWJpNnBhNTQ5dHRqbGsgZ3FlYjBpNnY3MzdrZnU1bWQwZjNldWtqbGdAZw",
+  "sequence": 1,
+  "updated": "2008-10-24T23:08:09.010Z",
+  "summary": "This is a test event",
   "start": {
     "dateTimes": "2008-09-24T10:30:00-07:00"
-  }, 
-  "etag": "\"2449779378020000\"", 
+  },
+  "etag": "\"2449779378020000\"",
   "organizer": {
-    "self": true, 
-    "displayName": "Some Person", 
+    "self": true,
+    "displayName": "Some Person",
     "email": "some.person@gmail.com"
-  }, 
+  },
   "creator": {
-    "displayName": "Some Person", 
+    "displayName": "Some Person",
     "email": "some.person@gmail.com"
-  }, 
-  "id": "fhru34kt6ikmr20knd2456l12n"
+  },
+  "id": "fhru34kt6ikmr20knd2456l12n",
+  "extendedProperties": {
+    "shared": {
+      "key": "value"
+    }
+  }
 }

--- a/test/mocks/query_events.json
+++ b/test/mocks/query_events.json
@@ -1,45 +1,50 @@
 {
-  "kind": "calendar#events", 
-  "defaultReminders": [], 
-  "description": "My Personal Events Calendar", 
+  "kind": "calendar#events",
+  "defaultReminders": [],
+  "description": "My Personal Events Calendar",
   "items": [
     {
-      "status": "confirmed", 
-      "kind": "calendar#event", 
+      "status": "confirmed",
+      "kind": "calendar#event",
       "end": {
         "dateTime": "2008-09-24T11:00:00-07:00"
-      }, 
-      "description": "My Test Event", 
-      "created": "2008-09-18T21:17:11.000Z", 
-      "iCalUID": "fhru34kt6ikmr20knd2456l08n@google.com", 
+      },
+      "description": "My Test Event",
+      "created": "2008-09-18T21:17:11.000Z",
+      "iCalUID": "fhru34kt6ikmr20knd2456l08n@google.com",
       "reminders": {
         "useDefault": true
-      }, 
-      "htmlLink": "https://www.google.com/calendar/event?eid=dDAwam5wcWMwOHJjYWJpNnBhNTQ5dHRqbGsgZ3FlYjBpNnY3MzdrZnU1bWQwZjNldWtqbGdAZw", 
-      "sequence": 1, 
-      "updated": "2008-10-24T23:08:09.010Z", 
+      },
+      "htmlLink": "https://www.google.com/calendar/event?eid=dDAwam5wcWMwOHJjYWJpNnBhNTQ5dHRqbGsgZ3FlYjBpNnY3MzdrZnU1bWQwZjNldWtqbGdAZw",
+      "sequence": 1,
+      "updated": "2008-10-24T23:08:09.010Z",
       "summary": "Test Event",
       "colorId": "3",
       "start": {
         "dateTime": "2008-09-24T10:30:00-07:00"
-      }, 
-      "etag": "\"2449779378020000\"", 
+      },
+      "etag": "\"2449779378020000\"",
       "organizer": {
-        "self": true, 
-        "displayName": "Some Person", 
+        "self": true,
+        "displayName": "Some Person",
         "email": "some.person@gmail.com"
-      }, 
+      },
       "creator": {
-        "displayName": "Some Person", 
+        "displayName": "Some Person",
         "email": "some.person@gmail.com"
-      }, 
-      "id": "fhru34kt6ikmr20knd2456l08n"
+      },
+      "id": "fhru34kt6ikmr20knd2456l08n",
+      "extendedProperties": {
+        "shared": {
+          "key": "value"
+        }
+      }
     }
-  ], 
-  "updated": "2014-11-15T22:32:46.965Z", 
-  "summary": "My Events Calendar", 
-  "etag": "\"1234567890123000\"", 
-  "nextSyncToken": "AKi8uge987ECEIjyiZnV_cECGAU=", 
-  "timeZone": "America/Los_Angeles", 
+  ],
+  "updated": "2014-11-15T22:32:46.965Z",
+  "summary": "My Events Calendar",
+  "etag": "\"1234567890123000\"",
+  "nextSyncToken": "AKi8uge987ECEIjyiZnV_cECGAU=",
+  "timeZone": "America/Los_Angeles",
   "accessRole": "owner"
 }

--- a/test/mocks/repeating_events.json
+++ b/test/mocks/repeating_events.json
@@ -1,48 +1,53 @@
 {
-  "kind": "calendar#events", 
-  "defaultReminders": [], 
-  "description": "My Personal Events Calendar", 
+  "kind": "calendar#events",
+  "defaultReminders": [],
+  "description": "My Personal Events Calendar",
   "items": [
     {
-      "status": "confirmed", 
-      "kind": "calendar#event", 
+      "status": "confirmed",
+      "kind": "calendar#event",
       "end": {
-        "timeZone": "America/Los_Angeles", 
+        "timeZone": "America/Los_Angeles",
         "dateTime": "2014-11-15T18:00:00-08:00"
-      }, 
-      "created": "2014-11-17T00:45:30.000Z", 
-      "iCalUID": "fhru34kt6ikmr20knd2456l08n@google.com", 
+      },
+      "created": "2014-11-17T00:45:30.000Z",
+      "iCalUID": "fhru34kt6ikmr20knd2456l08n@google.com",
       "reminders": {
         "useDefault": true
-      }, 
-      "htmlLink": "https://www.google.com/calendar/event?eid=MjRmNHZhY2pzY3A1YjB0NHE2OThoMGs2YXNfMjAxNDExMTZUMDEwMDAwWiBncWViMGk2djczN2tmdTVtZDBmM2V1a2psZ0Bn", 
-      "sequence": 0, 
-      "updated": "2014-11-17T00:45:30.431Z", 
-      "summary": "Test Repeating Events", 
+      },
+      "htmlLink": "https://www.google.com/calendar/event?eid=MjRmNHZhY2pzY3A1YjB0NHE2OThoMGs2YXNfMjAxNDExMTZUMDEwMDAwWiBncWViMGk2djczN2tmdTVtZDBmM2V1a2psZ0Bn",
+      "sequence": 0,
+      "updated": "2014-11-17T00:45:30.431Z",
+      "summary": "Test Repeating Events",
       "recurrence": [
         "RRULE:FREQ=DAILY;COUNT=3"
-      ], 
+      ],
       "start": {
-        "timeZone": "America/Los_Angeles", 
+        "timeZone": "America/Los_Angeles",
         "dateTime": "2014-11-15T17:00:00-08:00"
-      }, 
-      "etag": "\"2832370260862000\"", 
+      },
+      "etag": "\"2832370260862000\"",
       "organizer": {
-        "self": true, 
-        "displayName": "Some Person", 
+        "self": true,
+        "displayName": "Some Person",
         "email": "some.person@gmail.com"
-      }, 
+      },
       "creator": {
-        "displayName": "Some Person", 
+        "displayName": "Some Person",
         "email": "some.person@gmail.com"
-      }, 
-      "id": "fhru34kt6ikmr20knd2456l08n"
+      },
+      "id": "fhru34kt6ikmr20knd2456l08n",
+      "extendedProperties": {
+        "shared": {
+          "key": "value"
+        }
+      }
     }
-  ], 
-  "updated": "2014-11-17T00:45:30.522Z", 
-  "summary": "My Events Calendar", 
-  "etag": "\"1416185130522000\"", 
-  "nextSyncToken": "AKi8uge987ECEIjyiZnV_cECGAU=", 
-  "timeZone": "America/Los_Angeles", 
+  ],
+  "updated": "2014-11-17T00:45:30.522Z",
+  "summary": "My Events Calendar",
+  "etag": "\"1416185130522000\"",
+  "nextSyncToken": "AKi8uge987ECEIjyiZnV_cECGAU=",
+  "timeZone": "America/Los_Angeles",
   "accessRole": "owner"
 }

--- a/test/mocks/successful_login.json
+++ b/test/mocks/successful_login.json
@@ -1,6 +1,6 @@
 {
-  "access_token": "ya29.hYjPO0uHt63uWr5qmQtMEReZEvILcdGlPCOHDy6quKPyEQaQQvqaVAlLAVASaRm_O0a7vkZ91T8xyQ", 
-  "token_type": "Bearer", 
-  "expires_in": 3600, 
+  "access_token": "ya29.hYjPO0uHt63uWr5qmQtMEReZEvILcdGlPCOHDy6quKPyEQaQQvqaVAlLAVASaRm_O0a7vkZ91T8xyQ",
+  "token_type": "Bearer",
+  "expires_in": 3600,
   "refresh_token": "1/aJUy7pQzc4fUMX89BMMLeAfKcYteBKRMpQvf4fQFX0"
 }


### PR DESCRIPTION
This adds support for private and shared extended properties as indicated in the Calendar API doc:
https://developers.google.com/google-apps/calendar/v3/reference/events

The patch allows to insert any number of custom properties within an event, and then to query a calendar using those properties.

PS: Sorry my sublime auto corrected all the trailing whitespaces in the json files, so it looks as though it's a huge diff when it's in fact fairly simple.
