### PR TITLE
parse_options now accepts text query (q) param

### DIFF
--- a/lib/google/calendar.rb
+++ b/lib/google/calendar.rb
@@ -347,8 +347,11 @@ module Google
       options[:max_results] ||=  25
       options[:order_by] ||= 'startTime' # other option is 'updated'
       options[:expand_recurring_events] ||= true
-      options[:q] ||= ''
-      "&orderBy=#{options[:order_by]}&maxResults=#{options[:max_results]}&singleEvents=#{options[:expand_recurring_events]}&q=#{options[:q]}"
+      query_string = "&orderBy=#{options[:order_by]}"
+      query_string << "&maxResults=#{options[:max_results]}"
+      query_string << "&singleEvents=#{options[:expand_recurring_events]}"
+      query_string << "&q=#{options[:query]}" unless options[:query].nil?
+      query_string
     end
 
     #

--- a/lib/google/calendar.rb
+++ b/lib/google/calendar.rb
@@ -347,7 +347,8 @@ module Google
       options[:max_results] ||=  25
       options[:order_by] ||= 'startTime' # other option is 'updated'
       options[:expand_recurring_events] ||= true
-      "&orderBy=#{options[:order_by]}&maxResults=#{options[:max_results]}&singleEvents=#{options[:expand_recurring_events]}"
+      options[:q] ||= ''
+      "&orderBy=#{options[:order_by]}&maxResults=#{options[:max_results]}&singleEvents=#{options[:expand_recurring_events]}&q=#{options[:q]}"
     end
 
     #

--- a/test/test_google_calendar.rb
+++ b/test/test_google_calendar.rb
@@ -114,6 +114,14 @@ class TestGoogleCalendar < Minitest::Test
         @calendar.find_future_events()
       end
 
+      should "find future events with query" do
+        now = Time.now.utc
+        Time.stubs(:now).returns(now)
+        formatted_time = now.strftime("%FT%TZ")
+        @calendar.expects(:event_lookup).with("?timeMin=#{formatted_time}&orderBy=startTime&maxResults=25&singleEvents=true&q=w")
+        @calendar.find_future_events(max_results: 10, order_by: :startTime, q: 'w')
+      end
+
       should "return multiple events in range as array" do
         @client_mock.stubs(:body).returns( get_mock_body("events.json") )
         events = @calendar.events

--- a/test/test_google_calendar.rb
+++ b/test/test_google_calendar.rb
@@ -119,7 +119,7 @@ class TestGoogleCalendar < Minitest::Test
         Time.stubs(:now).returns(now)
         formatted_time = now.strftime("%FT%TZ")
         @calendar.expects(:event_lookup).with("?timeMin=#{formatted_time}&orderBy=startTime&maxResults=25&singleEvents=true&q=Test")
-        @calendar.find_future_events({max_results: 10, order_by: :startTime, q: 'Test'})
+        @calendar.find_future_events({max_results: 25, order_by: :startTime, query: 'Test'})
       end
 
       should "return multiple events in range as array" do

--- a/test/test_google_calendar.rb
+++ b/test/test_google_calendar.rb
@@ -118,8 +118,8 @@ class TestGoogleCalendar < Minitest::Test
         now = Time.now.utc
         Time.stubs(:now).returns(now)
         formatted_time = now.strftime("%FT%TZ")
-        @calendar.expects(:event_lookup).with("?timeMin=#{formatted_time}&orderBy=startTime&maxResults=25&singleEvents=true&q=w")
-        @calendar.find_future_events(max_results: 10, order_by: :startTime, q: 'w')
+        @calendar.expects(:event_lookup).with("?timeMin=#{formatted_time}&orderBy=startTime&maxResults=25&singleEvents=true&q=Test")
+        @calendar.find_future_events({max_results: 10, order_by: :startTime, q: 'Test'})
       end
 
       should "return multiple events in range as array" do


### PR DESCRIPTION
Hi Guys, great job with this gem!

I needed to add a textual query to find_future_events so I could quickly find all future events with some keyword. I ended up adding an optional 'q' param to parse_options, so that every method that uses it can now add 'q' to the options.

I added a test for it.