### PR TITLE
use JSON.generate instead of string concatenation

### DIFF
--- a/lib/google/event.rb
+++ b/lib/google/event.rb
@@ -277,14 +277,14 @@ module Google
       }
 
       if timezone_needed?
-        attributes.deep_merge!({ "start" => local_timezone_json, "end" => local_timezone_json })
+        attributes.merge!({ "start" => local_timezone_json, "end" => local_timezone_json })
       end
 
 
-      attributes.deep_merge!(recurrence_json)
-      attributes.deep_merge!(color_json)
-      attributes.deep_merge!(attendees_json)
-      attributes.deep_merge!(extended_properties_json)
+      attributes.merge!(recurrence_json)
+      attributes.merge!(color_json)
+      attributes.merge!(attendees_json)
+      attributes.merge!(extended_properties_json)
 
       JSON.generate attributes
     end
@@ -300,7 +300,7 @@ module Google
       return {} unless @attendees
 
       attendees = @attendees.map do |attendee|
-        attendee.slice 'displayName', 'email', 'responseStatus'
+        attendee.select { |k,v| ['displayName', 'email', 'responseStatus'].include?(k) }
       end
 
       { "attendees" => attendees }
@@ -312,7 +312,7 @@ module Google
     def reminders_json
       if reminders && reminders.is_a?(Hash) && reminders['overrides']
         overrides = reminders['overrides'].map do |reminder|
-          reminder.slice('method', 'minutes')
+          reminder.select {|k,v| ['method', 'minutes'].include?(v) }
         end
 
         { "useDefault" => false, "overrides" => overrides }
@@ -357,7 +357,7 @@ module Google
     def extended_properties_json
       return {} unless @extended_properties && (@extended_properties['shared'] || @extended_properties['private'])
 
-      { "extendedProperties" => @extendedProperties.slice('shared', 'private') }
+      { "extendedProperties" => @extendedProperties.select {|k,v| ['shared', 'private'].include?(k) } }
     end
 
     #

--- a/lib/google/event.rb
+++ b/lib/google/event.rb
@@ -292,7 +292,7 @@ module Google
 
     def color_json
       return {} unless color_id
-      { "colorId" => "color_id" }
+      { "colorId" => "#{color_id}" }
     end
     #
     # JSON representation of attendees

--- a/lib/google/event.rb
+++ b/lib/google/event.rb
@@ -277,7 +277,8 @@ module Google
       }
 
       if timezone_needed?
-        attributes.merge!({ "start" => local_timezone_json, "end" => local_timezone_json })
+        attributes['start'].merge!(local_timezone_json)
+        attributes['end'].merge!(local_timezone_json)
       end
 
 
@@ -311,11 +312,8 @@ module Google
     #
     def reminders_json
       if reminders && reminders.is_a?(Hash) && reminders['overrides']
-        overrides = reminders['overrides'].map do |reminder|
-          reminder.select {|k,v| ['method', 'minutes'].include?(v) }
-        end
 
-        { "useDefault" => false, "overrides" => overrides }
+        { "useDefault" => false, "overrides" => reminders['overrides'] }
       else
         { "useDefault" => true}
       end
@@ -341,13 +339,13 @@ module Google
     # JSON representation of recurrence rules for repeating events
     #
     def recurrence_json
-      return unless is_recurring_event?
+      return {} unless is_recurring_event?
 
       @recurrence[:until] = @recurrence[:until].strftime('%Y%m%dT%H%M%SZ') if @recurrence[:until]
       rrule = "RRULE:" + @recurrence.collect { |k,v| "#{k}=#{v}" }.join(';').upcase
       @recurrence[:until] = Time.parse(@recurrence[:until]) if @recurrence[:until]
 
-      { "recurrence" => rrule }
+      { "recurrence" => [rrule] }
     end
 
     #
@@ -357,7 +355,7 @@ module Google
     def extended_properties_json
       return {} unless @extended_properties && (@extended_properties['shared'] || @extended_properties['private'])
 
-      { "extendedProperties" => @extendedProperties.select {|k,v| ['shared', 'private'].include?(k) } }
+      { "extendedProperties" => @extended_properties.select {|k,v| ['shared', 'private'].include?(k) } }
     end
 
     #


### PR DESCRIPTION
We've seen numerous problems with this library due to the way it generates JSON - primarily, a newline is present in the description when we fetch it, it chokes when we come to update it.

I've updated this library to use ```JSON.generate``` instead, which should properly format newlines and other UTF-8 characters like emoji correctly, and ensured the tests pass locally.