### PR TITLE
Update dependencies to allow JSON  >= 1.8.3 and < 2.1

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ PATH
   specs:
     google_calendar (0.6.0)
       TimezoneParser (~> 0.2.0)
-      json (~> 2.0)
+      json (>= 1.8.3, < 2.1)
       signet (~> 0.7)
 
 GEM
@@ -21,7 +21,7 @@ GEM
     faraday (0.9.2)
       multipart-post (>= 1.2, < 3)
     insensitive_hash (0.3.3)
-    json (2.0.1)
+    json (2.0.2)
     jwt (1.5.4)
     metaclass (0.0.4)
     minitest (5.9.0)
@@ -71,4 +71,4 @@ DEPENDENCIES
   terminal-notifier-guard (~> 1.6)
 
 BUNDLED WITH
-   1.12.4
+   1.12.5

--- a/google_calendar.gemspec
+++ b/google_calendar.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.rubygems_version = "2.2.2"
 
   s.add_runtime_dependency(%q<signet>, ["~> 0.7"])
-  s.add_runtime_dependency(%q<json>, ["~> 2.0"])
+  s.add_runtime_dependency(%q<json>, [">= 1.8.3", "< 2.1"])
   s.add_runtime_dependency(%q<TimezoneParser>, ["~> 0.2.0"])
 
   s.add_development_dependency(%q<terminal-notifier-guard>, ["~> 1.6"])


### PR DESCRIPTION
JSON gem 2.x is not supported in activesupport 4.2.7.1, which restricts this
gem to being just used in >= Rails 5 apps, and JSON 1.8.3 still works as
intended with this gem.

Specs pass fine with 1.8.3, so unless there's a reason to not allow < 2.0 then
this PR allows the latest version of this gem to be used by more people.