### PR TITLE
Add transparency parameters to events json payload

### DIFF
--- a/lib/google/event.rb
+++ b/lib/google/event.rb
@@ -263,6 +263,7 @@ module Google
       attributes = {
         "summary" => title,
         "visibility" => visibility,
+        "transparency" => transparency,
         "description" => description,
         "location" => location,
         "start" => {

--- a/test/test_google_calendar.rb
+++ b/test/test_google_calendar.rb
@@ -365,6 +365,7 @@ class TestGoogleCalendar < Minitest::Test
         expected_structure = {
           "summary" => "Go Swimming",
           "visibility"=>"default",
+          "transparency"=>"opaque",
           "description" => "The polar bear plunge",
           "location" => "In the arctic ocean",
           "start" => {"dateTime" => "#{@event.start_time}"},

--- a/test/test_google_calendar.rb
+++ b/test/test_google_calendar.rb
@@ -425,7 +425,8 @@ class TestGoogleCalendar < Minitest::Test
         require 'timezone_parser'
         expected_structure = {
           "summary" => "Go Swimming",
-          "visibility"=>"default",
+          "visibility"=>"default",          
+          "transparency"=>"opaque",
           "description" => "The polar bear plunge",
           "location" => "In the arctic ocean",
           "start" => {"dateTime" => "#{@event.start_time}", "timeZone" => "#{TimezoneParser::getTimezones(Time.now.getlocal.zone).last}"},


### PR DESCRIPTION
The transparency setting does not get serialized in JSON, and as a result doesn't end up being saved on the server. The changes fixes that.