### PR TITLE
Update JSON format for all-day event

### DIFF
--- a/lib/google/event.rb
+++ b/lib/google/event.rb
@@ -266,12 +266,8 @@ module Google
         "transparency" => transparency,
         "description" => description,
         "location" => location,
-        "start" => {
-          "dateTime" => start_time
-        },
-        "end" => {
-          "dateTime" => end_time
-        },
+        "start" => time_or_all_day(start_time),
+        "end" => time_or_all_day(end_time),
         "reminders" => reminders_attributes,
         "guestsCanInviteOthers" => guests_can_invite_others,
         "guestsCanSeeOtherGuests" => guests_can_see_other_guests
@@ -443,6 +439,18 @@ module Google
     #
     def new_event?
       id == nil || id == ''
+    end
+
+    private
+
+    def time_or_all_day(time)
+      time = Time.parse(time) if time.is_a? String
+
+      if all_day?
+        { "date" => time.strftime("%Y-%m-%d") }
+      else
+        { "dateTime" => time.xmlschema }
+      end
     end
 
     protected

--- a/test/test_google_calendar.rb
+++ b/test/test_google_calendar.rb
@@ -381,6 +381,13 @@ class TestGoogleCalendar < Minitest::Test
         }
         assert_equal JSON.parse(@event.to_json), expected_structure
       end
+
+      should "return date instead of dateTime for all-day event" do
+        @event = Event.new(all_day: "2016-10-15")
+        json = JSON.parse(@event.to_json)
+        assert_equal json['start']['date'], "2016-10-15"
+        assert_equal json['end']['date'], "2016-10-16"
+      end
     end
 
     context "reminders" do
@@ -425,7 +432,7 @@ class TestGoogleCalendar < Minitest::Test
         require 'timezone_parser'
         expected_structure = {
           "summary" => "Go Swimming",
-          "visibility"=>"default",          
+          "visibility"=>"default",
           "transparency"=>"opaque",
           "description" => "The polar bear plunge",
           "location" => "In the arctic ocean",


### PR DESCRIPTION
For all-day event, `Event#to_json` will generate `start` and `end` attributes with `date` instead of `dateTime`.
Doing so will allow the event to be created as an actual all-day event in Google Calendar:

![All-day event](https://www.evernote.com/shard/s232/sh/93cb56db-9ca1-4253-b3f1-ab60c3dac660/7df0d5bfd6f39a3b/res/ebd3a9a6-5d18-4be5-96fb-07d92c22ed0f/skitch.png)

Reference: https://developers.google.com/google-apps/calendar/v3/reference/events/insert#end.date