### PR TITLE
Retain a given event ID when find_or_create_event_by_id creates a new event

### DIFF
--- a/lib/google/calendar.rb
+++ b/lib/google/calendar.rb
@@ -270,10 +270,14 @@ module Google
     # Works like the create_event method.
     #
     def find_or_create_event_by_id(id, &blk)
-      if id.nil?
-        setup_event(Event.new, &blk)
+      if id && event = find_event_by_id(id)[0]
+        setup_event(event, &blk)
+      elsif id
+        event = Event.new(id: id, new_event_with_id_specified: true)
+        setup_event(event, &blk)
       else
-        setup_event(find_event_by_id(id)[0] || Event.new, &blk)
+        event = Event.new
+        setup_event(event, &blk)
       end
     end
 

--- a/lib/google/event.rb
+++ b/lib/google/event.rb
@@ -537,7 +537,11 @@ module Google
     # Validates id format
     #
     def self.parse_id(id)
-      raise ArgumentError, "Event ID is invalid. Please check Google documentation: https://developers.google.com/google-apps/calendar/v3/reference/events/insert" unless id.gsub(/(^[a-v0-9]{5,1024}$)/o)
+      if id.to_s =~ /\A[a-v0-9]{5,1024}\Z/
+        id
+      else
+        raise ArgumentError, "Event ID is invalid. Please check Google documentation: https://developers.google.com/google-apps/calendar/v3/reference/events/insert"
+      end
     end
 
     #

--- a/lib/google/event.rb
+++ b/lib/google/event.rb
@@ -34,7 +34,7 @@ module Google
   class Event
     attr_reader :id, :raw, :html_link, :status, :transparency, :visibility
     attr_writer :reminders, :recurrence, :extended_properties
-    attr_accessor :title, :location, :calendar, :quickadd, :attendees, :description, :creator_name, :color_id, :guests_can_invite_others, :guests_can_see_other_guests
+    attr_accessor :title, :location, :calendar, :quickadd, :attendees, :description, :creator_name, :color_id, :guests_can_invite_others, :guests_can_see_other_guests, :new_event_with_id_specified
 
     #
     # Create a new event, and optionally set it's attributes.
@@ -70,6 +70,7 @@ module Google
       self.transparency = params[:transparency]
       self.all_day      = params[:all_day] if params[:all_day]
       self.creator_name = params[:creator]['displayName'] if params[:creator]
+      self.new_event_with_id_specified = !!params[:new_event_with_id_specified]
     end
 
     #
@@ -259,7 +260,6 @@ module Google
     # Google JSON representation of an event object.
     #
     def to_json
-
       attributes = {
         "summary" => title,
         "visibility" => visibility,
@@ -273,11 +273,14 @@ module Google
         "guestsCanSeeOtherGuests" => guests_can_see_other_guests
       }
 
+      if id
+        attributes["id"] = id
+      end
+
       if timezone_needed?
         attributes['start'].merge!(local_timezone_attributes)
         attributes['end'].merge!(local_timezone_attributes)
       end
-
 
       attributes.merge!(recurrence_attributes)
       attributes.merge!(color_attributes)
@@ -438,10 +441,14 @@ module Google
     # Returns true if this a new event.
     #
     def new_event?
-      id == nil || id == ''
+      new_event_with_id_specified? || id == nil || id == ''
     end
 
     private
+
+    def new_event_with_id_specified?
+      !!new_event_with_id_specified
+    end
 
     def time_or_all_day(time)
       time = Time.parse(time) if time.is_a? String

--- a/test/test_google_calendar.rb
+++ b/test/test_google_calendar.rb
@@ -279,6 +279,24 @@ class TestGoogleCalendar < Minitest::Test
   end # Connected context
 
   context "Event instance methods" do
+    context "#id=" do
+      should "retain a passed-in id" do
+        event = Event.new
+        event.id = '8os94knodtv84h0jh4pqq4ut35'
+        assert_equal event.id, '8os94knodtv84h0jh4pqq4ut35'
+      end
+      should "work with a passed-in NIL id" do
+        event = Event.new
+        event.id = nil
+        assert_equal event.id, nil
+      end
+      should "raise an error with an invalid ID" do
+        event = Event.new
+        assert_raises(ArgumentError) do
+          event.id = 'ZZZZ' # too short, invalid characters
+        end
+      end
+    end
     context "#all_day?" do
       context "when the event is marked as All Day in google calendar" do
         should "be true" do

--- a/test/test_google_calendar.rb
+++ b/test/test_google_calendar.rb
@@ -362,7 +362,12 @@ class TestGoogleCalendar < Minitest::Test
     end
 
     context "event json" do
-      should "be correct format" do
+      should "include ID key when ID specified" do
+        @event = Event.new(id: "nfej9pqigzneknf8llso0iehlv")
+        assert_equal JSON.parse(@event.to_json)["id"], "nfej9pqigzneknf8llso0iehlv"
+      end
+
+      should "be correct format without ID specified" do
         now = Time.now
         @event = Event.new
         @event.start_time = now


### PR DESCRIPTION
READY

I found that when passing an event ID to `find_or_create_event_by_id` it would not be kept in the case where a new event needed to be created. Though an event would be created successfully, it would have a Google-generated ID.

When passing the event ID of an existing event to `find_or_create_event_by_id`, all worked as expected.

I found that the `parse_id` method was inadvertently setting the id to nil, and also that the `id` key was not being sent to Google (not set in `Event#to_json`)

This PR corrects both issues, adds tests.



