### PR TITLE
Enable sendNotifications when creating, updating, deleting an Event

### DIFF
--- a/lib/google/calendar.rb
+++ b/lib/google/calendar.rb
@@ -288,12 +288,13 @@ module Google
     def save_event(event)
       method = event.new_event? ? :post : :put
       body = event.use_quickadd? ? nil : event.to_json
+      notifications = "sendNotifications=#{event.send_notifications?}"
       query_string =  if event.use_quickadd?
-        "/quickAdd?text=#{event.title}"
+        "/quickAdd?#{notifications}&text=#{event.title}"
       elsif event.new_event?
-        ''
+        "?#{notifications}"
       else # update existing event.
-        "/#{event.id}"
+        "/#{event.id}?#{notifications}"
       end
 
       send_events_request(query_string, method, body)
@@ -304,7 +305,8 @@ module Google
     # This is a callback used by the Event class.
     #
     def delete_event(event)
-      send_events_request("/#{event.id}", :delete)
+      notifications = "sendNotifications=#{event.send_notifications?}"
+      send_events_request("/#{event.id}?#{notifications}", :delete)
     end
 
     protected

--- a/lib/google/event.rb
+++ b/lib/google/event.rb
@@ -30,11 +30,12 @@ module Google
   # * +extended_properties+ - Custom properties which may be shared or private. Read Write
   # * +guests_can_invite_others+ - Whether attendees other than the organizer can invite others to the event (*true*, false). Read Write.
   # * +guests_can_see_other_guests+ - Whether attendees other than the organizer can see who the event's attendees are (*true*, false). Read Write.
+  # * +send_notifications+ - Whether to send notifications about the event update (true, *false*). Write only.
   #
   class Event
     attr_reader :id, :raw, :html_link, :status, :transparency, :visibility
     attr_writer :reminders, :recurrence, :extended_properties
-    attr_accessor :title, :location, :calendar, :quickadd, :attendees, :description, :creator_name, :color_id, :guests_can_invite_others, :guests_can_see_other_guests, :new_event_with_id_specified
+    attr_accessor :title, :location, :calendar, :quickadd, :attendees, :description, :creator_name, :color_id, :guests_can_invite_others, :guests_can_see_other_guests, :send_notifications, :new_event_with_id_specified
 
     #
     # Create a new event, and optionally set it's attributes.
@@ -60,9 +61,10 @@ module Google
     # event.extendedProperties = {'shared' => {'custom_str' => 'some custom string'}}
     # event.guests_can_invite_others = false
     # event.guests_can_see_other_guests = false
+    # event.send_notifications = true
     #
     def initialize(params = {})
-      [:id, :status, :raw, :html_link, :title, :location, :calendar, :quickadd, :attendees, :description, :reminders, :recurrence, :start_time, :end_time, :color_id, :extended_properties, :guests_can_invite_others, :guests_can_see_other_guests].each do |attribute|
+      [:id, :status, :raw, :html_link, :title, :location, :calendar, :quickadd, :attendees, :description, :reminders, :recurrence, :start_time, :end_time, :color_id, :extended_properties, :guests_can_invite_others, :guests_can_see_other_guests, :send_notifications].each do |attribute|
         instance_variable_set("@#{attribute}", params[attribute])
       end
 
@@ -443,6 +445,14 @@ module Google
     def new_event?
       new_event_with_id_specified? || id == nil || id == ''
     end
+
+    #
+    # Returns true if notifications were requested to be sent
+    #
+    def send_notifications?
+      !!send_notifications
+    end
+
 
     private
 

--- a/test/test_google_calendar.rb
+++ b/test/test_google_calendar.rb
@@ -297,6 +297,27 @@ class TestGoogleCalendar < Minitest::Test
         end
       end
     end
+
+    context "send_notifications" do
+      should "work when initialized with true" do
+        event = Event.new(:send_notifications => true)
+        assert event.send_notifications?
+      end
+
+      should "work when initialized with false" do
+        event = Event.new(:send_notifications => false)
+        refute event.send_notifications?
+      end
+
+      should "be dynamic" do
+        event = Event.new
+        event.send_notifications = false
+        refute event.send_notifications?
+        event.send_notifications = true
+        assert event.send_notifications?
+      end
+    end
+
     context "#all_day?" do
       context "when the event is marked as All Day in google calendar" do
         should "be true" do


### PR DESCRIPTION
READY

Adds the ability to tell Google API to send notifications to attendees about changes to an event, per the documentation.

Adds unit tests for the Event object, but unsure how or if to unit test the methods in the calendar class.  I've verified the behavior is as I expect when interacting with the API for create/update/delete (:post, :put, :delete verbs).