### PR TITLE
Add missing Google Calendar API errors

### DIFF
--- a/lib/google/connection.rb
+++ b/lib/google/connection.rb
@@ -160,16 +160,16 @@ module Google
         when 401 then raise InvalidCredentialsError, response.body
         when 403 
           case JSON.parse(response.body)["error"]["message"]
+          when "Forbidden"
+            raise ForbiddenError, response.body
           when "Daily Limit Exceeded"
-            raise InvalidCredentialsError, response.body
+            raise DailyLimitExceededError, response.body
           when "User Rate Limit Exceeded"
             raise UserRateLimitExceededError, response.body
           when "Rate Limit Exceeded"
             raise RateLimitExceededError, response.body
           when "Calendar usage limits exceeded."
             raise CalendarUsageLimitExceededError, response.body
-          when "Forbidden"
-            raise ForbiddenError, response.body
           else
             raise ForbiddenError, response.body
           end

--- a/lib/google/connection.rb
+++ b/lib/google/connection.rb
@@ -157,7 +157,27 @@ module Google
     def check_for_errors(response) #:nodoc
       case response.status
         when 400 then raise HTTPRequestFailed, response.body
+        when 401 then raise InvalidCredentialsError, response.body
+        when 403 
+          case JSON.parse(response.body)["error"]["message"]
+          when "Daily Limit Exceeded"
+            raise InvalidCredentialsError, response.body
+          when "User Rate Limit Exceeded"
+            raise UserRateLimitExceededError, response.body
+          when "Rate Limit Exceeded"
+            raise RateLimitExceededError, response.body
+          when "Calendar usage limits exceeded."
+            raise CalendarUsageLimitExceededError, response.body
+          when "Forbidden"
+            raise ForbiddenError, response.body
+          else
+            raise ForbiddenError, response.body
+          end
         when 404 then raise HTTPNotFound, response.body
+        when 409 then raise RequestedIdentifierAlreadyExistsError, response.body
+        when 410 then raise GoneError, response.body
+        when 412 then raise PreconditionFailedError, response.body
+        when 500 then raise BackendError, response.body
       end
     end
 

--- a/lib/google/errors.rb
+++ b/lib/google/errors.rb
@@ -2,7 +2,4 @@ module Google
   class HTTPRequestFailed < StandardError; end
   class HTTPAuthorizationFailed < StandardError; end
   class HTTPNotFound < StandardError; end
-  class HTTPTooManyRedirections < StandardError; end
-  class InvalidCalendar < StandardError; end
-  class CalenarIDMissing < StandardError; end
 end

--- a/lib/google/errors.rb
+++ b/lib/google/errors.rb
@@ -1,5 +1,78 @@
 module Google
-  class HTTPRequestFailed < StandardError; end
+  # Signet::AuthorizationError
+  # Not part of Google Calendar API Errors
   class HTTPAuthorizationFailed < StandardError; end
+
+  # Google Calendar API Errors per documentation
+  # https://developers.google.com/google-apps/calendar/v3/errors
+  
+  # 400: Bad Request
+  #
+  # User error. This can mean that a required field or parameter has not been
+  # provided, the value supplied is invalid, or the combination of provided
+  # fields is invalid.
+  class HTTPRequestFailed < StandardError; end
+
+  # 401: Invalid Credentials
+  #
+  # Invalid authorization header. The access token you're using is either
+  # expired or invalid.
+  class InvalidCredentialsError < StandardError; end
+
+  # 403: Daily Limit Exceeded
+  #
+  # The Courtesy API limit for your project has been reached.
+  class DailyLimitExceededError < StandardError; end
+
+  # 403: User Rate Limit Exceeded
+  #
+  # The per-user limit from the Developer Console has been reached.
+  class UserRateLimitExceededError < StandardError; end
+  
+  # 403: Rate Limit Exceeded
+  #
+  # The user has reached Google Calendar API's maximum request rate per
+  # calendar or per authenticated user.
+  class RateLimitExceededError < StandardError; end
+
+  # 403: Calendar usage limits exceeded
+  #
+  # The user reached one of the Google Calendar limits in place to protect
+  # Google users and infrastructure from abusive behavior.
+  class CalendarUsageLimitExceededError < StandardError; end
+
+  # 404: Not Found
+  #
+  # The specified resource was not found.
   class HTTPNotFound < StandardError; end
+
+  # 409: The requested identifier already exists
+  #
+  # An instance with the given ID already exists in the storage.
+  class RequestedIdentifierAlreadyExistsError < StandardError; end
+
+  # 410: Gone
+  #
+  # SyncToken or updatedMin parameters are no longer valid. This error can also
+  # occur if a request attempts to delete an event that has already been
+  # deleted.
+  class GoneError < StandardError; end
+
+  # 412: Precondition Failed
+  #
+  # The etag supplied in the If-match header no longer corresponds to the
+  # current etag of the resource.
+  class PreconditionFailedError < StandardError; end
+
+  # 500: Backend Error
+  #
+  # An unexpected error occurred while processing the request.
+  class BackendError < StandardError; end
+
+  #
+  # 403: Forbidden Error
+  #
+  # User has no authority to conduct the requested operation on the resource.
+  # This is not a part of official Google Calendar API Errors documentation.
+  class ForbiddenError < StandardError; end
 end

--- a/test/test_google_calendar.rb
+++ b/test/test_google_calendar.rb
@@ -27,7 +27,7 @@ class TestGoogleCalendar < Minitest::Test
       should "login with auth code" do
         @client_mock.stubs(:body).returns( get_mock_body("login_with_auth_code_success.json") )
         @calendar.login_with_auth_code('4/QzBU-n6GXnHUkorG0fiu6AhoZtIjW53qKLOREiJWFpQ.wn0UfiyaDlEfEnp6UAPFm0EazsV1kwI')
-        assert_equal @calendar.auth_code, nil # the auth_code is discarded after it is used.
+        assert_nil @calendar.auth_code # the auth_code is discarded after it is used.
         assert_equal @calendar.access_token, @access_token
         assert_equal @calendar.refresh_token, '1/aJUy7pQzc4fUMX89BMMLeAfKcYteBKRMpQvf4fQFX0'
       end
@@ -248,7 +248,7 @@ class TestGoogleCalendar < Minitest::Test
 
         @client_mock.stubs(:body).returns('')
         event.delete
-        assert_equal event.id, nil
+        assert_nil event.id
       end
 
       should "throw exception on bad request" do
@@ -258,14 +258,14 @@ class TestGoogleCalendar < Minitest::Test
         end
       end
 
-      should "create event when id is NIL" do
+      should "create event when id is nil" do
         @client_mock.stubs(:body).returns( get_mock_body("find_event_by_id.json") )
 
-        event = @calendar.find_or_create_event_by_id(NIL) do |e|
-          e.title = 'New Event Update when id is NIL'
+        event = @calendar.find_or_create_event_by_id(nil) do |e|
+          e.title = 'New Event Update when id is nil'
         end
 
-        assert_equal event.title, 'New Event Update when id is NIL'
+        assert_equal event.title, 'New Event Update when id is nil'
       end
 
       should "provide the calendar summary" do
@@ -285,10 +285,10 @@ class TestGoogleCalendar < Minitest::Test
         event.id = '8os94knodtv84h0jh4pqq4ut35'
         assert_equal event.id, '8os94knodtv84h0jh4pqq4ut35'
       end
-      should "work with a passed-in NIL id" do
+      should "work with a passed-in nil id" do
         event = Event.new
         event.id = nil
-        assert_equal event.id, nil
+        assert_nil event.id
       end
       should "raise an error with an invalid ID" do
         event = Event.new


### PR DESCRIPTION
There are several Google Calendar API errors that are not handled in the gem. This PR adds those errors and checks for them. It also adds a Forbidden error for unauthorized access to a resource.

I still need to add tests, but I'm not sure how to write them for this gem. I'd like to get some comments from the maintainer on how to approach this.