### PR TITLE
Switching transparency default to “opaque”

### DIFF
--- a/lib/google/event.rb
+++ b/lib/google/event.rb
@@ -216,10 +216,10 @@ module Google
     # You can pass true or false.  Defaults to transparent.
     #
     def transparency=(val)
-      if val == false || val.to_s.downcase == 'opaque'
-        @transparency = 'opaque'
-      else
+      if val == true || val.to_s.downcase == 'transparent'
         @transparency = 'transparent'
+      else
+        @transparency = 'opaque'
       end
     end
 

--- a/test/test_google_calendar.rb
+++ b/test/test_google_calendar.rb
@@ -502,14 +502,29 @@ class TestGoogleCalendar < Minitest::Test
     end
 
     context "transparency" do
-      should "be transparent" do
-        @event = Event.new(:transparency => true)
-        assert @event.transparent?
+      should "be opaque when nil" do
+        @event = Event.new
+        assert @event.opaque?
+      end
+
+      should "be opaque when transparency = opaque" do
+        @event = Event.new(:transparency => 'opaque')
+        assert @event.opaque?
       end
 
       should "be opaque?" do
         @event = Event.new(:transparency => false)
         assert @event.opaque?
+      end
+
+      should "be transparent" do
+        @event = Event.new(:transparency => true)
+        assert @event.transparent?
+      end
+
+      should "be transparent when transparency = transparent" do
+        @event = Event.new(:transparency => 'transparent')
+        assert @event.transparent?
       end
     end
 


### PR DESCRIPTION
The GoogleCalendar API is returning no 'transparency' property for busy events. According to the [docs](https://developers.google.com/calendar/v3/reference/events#transparency), `opaque` is considered the default. 