### PR TITLE
Enable bundler caching for travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: ruby
+cache: bundler
 rvm:
   - 2.4
   - 2.5


### PR DESCRIPTION
Would be interested to know why bundler cache hasn't been enabled for Travis. Thank you.