### PR TITLE
Add sync functionality

### DIFF
--- a/lib/google/calendar.rb
+++ b/lib/google/calendar.rb
@@ -248,11 +248,11 @@ module Google
     #   a hash with a next_sync_token plus an empty [:events] array if nothing found.
     #   a hash with a next_sync_token plus an array with one element if only one event found.
     #   a hash with a next_sync_token plus an array of events if many found.
-    #   a hash with a next_sync_token and next_page_token, plus an array of events if many found.
+    #   a hash with a next_sync_token and page_token, plus an array of events if many found.
     #
     def incremental_sync(sync_token: '', page_token: nil)
-      page_token = next_page_token == nil ? nil : "&pageToken=#{next_page_token}"
-      sync_event_lookup("?syncToken=#{sync_token}#{page_token.to_s}", sync_token, next_page_token)
+      page_token_string = page_token == nil ? '' : "&pageToken=#{page_token}"
+      sync_event_lookup("?syncToken=#{sync_token}#{page_token_string}", sync_token, page_token)
     end
 
     #

--- a/lib/google/synchronize.rb
+++ b/lib/google/synchronize.rb
@@ -1,0 +1,19 @@
+module Google
+  class Synchronize
+    #
+    # Convenience method used to build a hash for incremental sync.
+    # Includes events from a Google feed plus necessary synchronization tokens.
+    #
+    def self.synchronize_hash(response, calendar)
+      events = Event.build_from_google_feed(response, calendar)
+      unless events.empty?
+        events = events.length > 1 ? events : events[0]
+      end
+      result = { events: events }
+      result[:next_sync_token] = response['nextSyncToken'] if response['nextSyncToken']
+      result[:next_page_token] = response['nextPageToken'] if response['nextPageToken']
+      
+      return result
+    end
+  end
+end

--- a/lib/google/synchronize.rb
+++ b/lib/google/synchronize.rb
@@ -7,7 +7,7 @@ module Google
     def self.synchronize_hash(response, calendar)
       events = Event.build_from_google_feed(response, calendar)
       unless events.empty?
-        events = events.length > 1 ? events : events[0]
+        events = events.length > 1 ? events : [events[0]]
       end
       result = { events: events }
       result[:next_sync_token] = response['nextSyncToken'] if response['nextSyncToken']

--- a/lib/google_calendar.rb
+++ b/lib/google_calendar.rb
@@ -6,4 +6,5 @@ module Google
   require 'google/connection'
   require 'google/event'
   require 'google/freebusy'
+  require 'google/synchronize'
 end


### PR DESCRIPTION
Hi there,

This pull request is incomplete - more so a beginning to a conversation that will hopefully lead to a merge after some fixes to this PR.

I had a lot of difficulty adding this since I wasn't sure how to make this stylistically similar to the northworld repo. Event list calls traditionally return an array, but with syncing, it's important to also receive nextPageToken and nextSyncToken in the responses, meaning a hash is more appropriate.

I am looking for suggestions on how to make it more northworld-y. Once that is done, I will add all applicable tests and notify when I am ready for a review with the intention of merging.

The code I wrote is based on the supporting docs here:
https://developers.google.com/calendar/api/guides/sync

Thank you for your time,

Ian