### PR TITLE
Require Ruby >= 3.2 in gemspec

### DIFF
--- a/google_calendar.gemspec
+++ b/google_calendar.gemspec
@@ -6,6 +6,7 @@ Gem::Specification.new do |s|
   s.date = "2026-07-07"
 
   s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
+  s.required_ruby_version = ">= 3.2"
 
   s.authors = ["Steve Zich"]
   s.email = "steve.zich@gmail.com"


### PR DESCRIPTION
Follow-up to #299. Makes the Ruby 3.2+ floor explicit in the gemspec.

Without `required_ruby_version`, a user on an older Ruby could `gem install google_calendar` and receive 0.7.0 — which requires Ruby 3.2+ (signet 0.22 floor) and won't work for them. Setting `>= 3.2` makes RubyGems resolve those users to the last compatible release (0.6.4) instead, and clears the corresponding `gem build` warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)