### PR TITLE
Remove stale hardcoded rubygems_version from gemspec

### DIFF
--- a/google_calendar.gemspec
+++ b/google_calendar.gemspec
@@ -25,7 +25,6 @@ Gem::Specification.new do |s|
   s.test_files    = `git ls-files -- {test,spec,features}/*`.split("\n")
 
   s.require_paths = ["lib"]
-  s.rubygems_version = "2.7.6"
 
   s.add_runtime_dependency(%q<addressable>, ["> 2.7.0"])
   s.add_runtime_dependency(%q<signet>, ["~> 0.7"])


### PR DESCRIPTION
Drops the leftover `s.rubygems_version = "2.7.6"` line (a 2018 build artifact).

RubyGems overwrites this field at build time, so the hardcoded value was both inaccurate and the source of a `expected RubyGems version 3.7.1, was 2.7.6` warning during `gem build`. Removing it is purely cosmetic — no effect on the built gem.

Cleanup only; not worth re-tagging v0.7.0 for. Rides into the next release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)